### PR TITLE
Truncate long filenames for Protocol export [#137891257]

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -83,7 +83,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
         render
       }
       format.xlsx {
-        @statuses_hidden = params[:statuses_hidden]
+        @statuses_hidden = params[:statuses_hidden] || %w(draft first_draft)
         response.headers['Content-Disposition'] = "attachment; filename=\"(#{@protocol.id}) Consolidated Corporate Study Budget.xlsx\""
       }
     end

--- a/app/models/arm.rb
+++ b/app/models/arm.rb
@@ -68,8 +68,8 @@ class Arm < ActiveRecord::Base
   end
 
   def sanitized_name
-    #Sanitized for Excel
-    name.gsub(/\[|\]|\*|\/|\\|\?|\:/, ' ')
+    # Sanitized for Excel
+    name.gsub(/\[|\]|\*|\/|\\|\?|\:/, ' ').truncate(31) 
   end
 
   def update_liv_subject_counts

--- a/app/views/dashboard/protocols/show.xlsx.axlsx
+++ b/app/views/dashboard/protocols/show.xlsx.axlsx
@@ -98,6 +98,8 @@ arm_r_totals = {}
       current_row = sheet.rows.length + 1
       line_items_visits.each do |liv|
         @line_item_style_array = [default, default, default, money, money, money]
+        puts n_columns.inspect
+        puts current_row.inspect
         n_columns_sum = sum(n_columns, current_row)
         nr_cell = "#{negotiated_reimbursement_column}#{current_row}"
         your_cost_cell = "#{research_cost_column}#{current_row}"

--- a/app/views/dashboard/protocols/show.xlsx.axlsx
+++ b/app/views/dashboard/protocols/show.xlsx.axlsx
@@ -98,8 +98,6 @@ arm_r_totals = {}
       current_row = sheet.rows.length + 1
       line_items_visits.each do |liv|
         @line_item_style_array = [default, default, default, money, money, money]
-        puts n_columns.inspect
-        puts current_row.inspect
         n_columns_sum = sum(n_columns, current_row)
         nr_cell = "#{negotiated_reimbursement_column}#{current_row}"
         your_cost_cell = "#{research_cost_column}#{current_row}"


### PR DESCRIPTION
The spreadsheet rendered by ProtocolsController#show breaks when encountering an Arm with long names. Also added a default to `@statuses_hidden` in that controller action to keep bookmarked links working.