### PR TITLE
wth - fix otf service associations

### DIFF
--- a/app/models/line_items_visit.rb
+++ b/app/models/line_items_visit.rb
@@ -38,6 +38,7 @@ class LineItemsVisit < ActiveRecord::Base
 
   validates_numericality_of :subject_count
   validate :subject_count_valid
+  validate :pppv_line_item
 
   after_save :set_arm_edited_flag_on_subjects
 
@@ -47,6 +48,12 @@ class LineItemsVisit < ActiveRecord::Base
   def subject_count_valid
     if subject_count && subject_count > arm.subject_count
       errors.add(:blank, I18n.t('errors.line_items_visits.subject_count_invalid', arm_subject_count: arm.subject_count))
+    end
+  end
+
+  def pppv_line_item
+    if self.line_item.one_time_fee
+      errors.add(:_, 'Line Items Visits should only belong to a PPPV LineItem')
     end
   end
 

--- a/lib/tasks/fix_otf_service_associations.rake
+++ b/lib/tasks/fix_otf_service_associations.rake
@@ -1,0 +1,13 @@
+task fix_otf_service_associations: :environment do
+  LineItem.all.each do |line_item|
+    if line_item.one_time_fee
+      line_item.line_items_visits.destroy
+    end
+  end
+
+  Arm.all.each do |arm|
+    unless arm.line_items_visits.present?
+      arm.destroy
+    end
+  end
+end

--- a/spec/factories/line_items_visit.rb
+++ b/spec/factories/line_items_visit.rb
@@ -23,4 +23,8 @@ FactoryGirl.define do
   factory :line_items_visit do
     subject_count 1
   end
+
+  trait :without_validations do
+    to_create { |instance| instance.save(validate: false) }
+  end
 end

--- a/spec/features/service_calendar/user_interacts_with_quantity_billing_tab_spec.rb
+++ b/spec/features/service_calendar/user_interacts_with_quantity_billing_tab_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'User interacts with Quantity/Billing tab', js: true do
       li        = create(:line_item, sub_service_request: ssr, service_request: @sr, service: service)
       @arm      = create(:arm, protocol: protocol)
       vg        = create(:visit_group, arm: @arm)
-      liv       = create(:line_items_visit, line_item: li, arm: @arm)
+      liv       = create(:line_items_visit, :without_validations, line_item: li, arm: @arm)
       visit     = create(:visit, line_items_visit: liv, visit_group: vg)
 
       visit service_calendar_service_request_path(@sr)

--- a/spec/features/service_calendar/user_interacts_with_template_tab_spec.rb
+++ b/spec/features/service_calendar/user_interacts_with_template_tab_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'User interacts with Template tab', js: true do
       li        = create(:line_item, sub_service_request: ssr, service_request: @sr, service: service)
       @arm      = create(:arm, protocol: protocol)
       vg        = create(:visit_group, arm: @arm)
-      liv       = create(:line_items_visit, line_item: li, arm: @arm)
+      liv       = create(:line_items_visit, :without_validations, line_item: li, arm: @arm)
       visit     = create(:visit, line_items_visit: liv, visit_group: vg)
 
       visit service_calendar_service_request_path(@sr)

--- a/spec/lib/dashboard/service_calendars_spec.rb
+++ b/spec/lib/dashboard/service_calendars_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Dashboard::ServiceCalendars do
         # this LIV should not appear (it is not PPPV)
         service_otf = create(:service, :without_validations, organization: org_A, one_time_fee: true)
         li_otf = create(:line_item, :without_validations, service: service_otf, sub_service_request: ssr)
-        create(:line_items_visit, arm: arm, line_item: li_otf, sub_service_request: ssr)
 
         # this LIV should not appear (not associated with arm)
         wrong_arm = create(:arm, :without_validations)
@@ -117,7 +116,6 @@ RSpec.describe Dashboard::ServiceCalendars do
           # this LIV should not appear (it is not PPPV)
           service_otf = create(:service, :without_validations, organization: org_A, one_time_fee: true)
           li_otf = create(:line_item, :without_validations, service: service_otf, sub_service_request: ssr)
-          create(:line_items_visit, arm: arm, line_item: li_otf, sub_service_request: ssr)
 
           # this LIV should not appear (associated with another SSR)
           another_ssr = create(:sub_service_request, :without_validations, organization: org_A)
@@ -156,7 +154,6 @@ RSpec.describe Dashboard::ServiceCalendars do
           # this LIV should not appear (it is not PPPV)
           service_otf = create(:service, :without_validations, organization: org_A, one_time_fee: true)
           li_otf = create(:line_item, :without_validations, service: service_otf, service_request: sr, sub_service_request: ssr)
-          create(:line_items_visit, arm: arm, line_item: li_otf)
 
           # this LIV should not appear (associated with another SR)
           another_sr = create(:service_request_without_validations)

--- a/spec/models/arm/service_list_spec.rb
+++ b/spec/models/arm/service_list_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Arm, type: :model do
       # org2 <- s2(otf)
       @s2   = create(:service, organization: @org2, one_time_fee: true)
       @li2  = create(:line_item, service: @s2, service_request: @sr)
-      @liv2 = create(:line_items_visit, arm: @arm, line_item: @li2)
 
       # org3(ssrs)* <- org4(ssrs) <- s3(not otf)
       @org3 = create(:organization, process_ssrs: true, parent: nil)

--- a/spec/models/line_items_visit_spec.rb
+++ b/spec/models/line_items_visit_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe LineItemsVisit do
     expect(line_items_visit.visits).to eq [ ]
   end
 
+  it 'should only belong to a PPPV LineItem' do
+    arm = create(:arm, :without_validations)
+    line_item = create(:line_item, :one_time_fee, :without_validations)
+    line_items_visit = build(:line_items_visit, line_item_id: line_item.id, arm_id: arm.id)
+
+    expect(line_items_visit).not_to be_valid
+  end
+
   describe "methods" do
 
     before :each do
@@ -194,7 +202,7 @@ RSpec.describe LineItemsVisit do
       describe 'any visit quantities customized' do
         let!(:protocol)          { create(:protocol_without_validations) }
         let!(:arm)               { create(:arm, protocol: protocol) }
-        let!(:line_items_visit1) { create(:line_items_visit, arm_id: arm.id) }
+        let!(:line_items_visit1) { create(:line_items_visit, :without_validations, arm_id: arm.id) }
         let!(:visit_group)       { create(:visit_group, arm_id: arm.id)}
         let!(:visit1)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }
         let!(:visit2)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }

--- a/spec/models/visit_group_spec.rb
+++ b/spec/models/visit_group_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "VisitGroup" do
   describe 'any visit quantities customized' do
     let!(:protocol)          { create(:protocol_without_validations) }
     let!(:arm)               { create(:arm, protocol: protocol) }
-    let!(:line_items_visit1) { create(:line_items_visit, arm_id: arm.id, line_item_id: line_item.id) }
+    let!(:line_items_visit1) { create(:line_items_visit, :without_validations, arm_id: arm.id, line_item_id: line_item.id) }
     let!(:visit_group)       { create(:visit_group, arm_id: arm.id)}
     let!(:visit1)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }
     let!(:visit2)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Visit' do
   build_service_request_with_study
 
   let!(:arm)               { create(:arm, protocol: study) }
-  let!(:line_items_visit1) { create(:line_items_visit, arm_id: arm.id, line_item_id: line_item.id) }
+  let!(:line_items_visit1) { create(:line_items_visit, :without_validations, arm_id: arm.id, line_item_id: line_item.id) }
   let!(:visit_group)       { create(:visit_group, arm_id: arm.id)}
   let!(:visit1)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }
 

--- a/spec/support/capybara_support.rb
+++ b/spec/support/capybara_support.rb
@@ -174,7 +174,6 @@ module CapybaraSupport
 
     arm = create(:arm, protocol_id: project.id, subject_count: 2, visit_count: 10)
 
-    line_items_visit = create(:line_items_visit, arm_id: arm.id, subject_count: arm.subject_count)
 
     survey = create(:survey, title: "System Satisfaction survey", description: nil, access_code: "system-satisfaction-survey", reference_identifier: nil,
                                          data_export_identifier: nil, common_namespace: nil, common_identifier: nil, active_at: nil, inactive_at: nil, css_url: nil,


### PR DESCRIPTION
Created rake task to migrate data.
1. Destroy LineItemsVisits that belong to a OTF LineItem.
2. Destroy any arms that lack LineItemsVisits to cleanup.
3. Add validation that ensures a LineItemsVisit should only belong to a
PPPV LineItem.
[#137959649]