### PR TITLE
wth - Form Builder validations

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -6,4 +6,15 @@ class Questionnaire < ActiveRecord::Base
   scope :active, -> { where(active: true) }
 
   accepts_nested_attributes_for :items, allow_destroy: true
+
+  validate :at_least_one_item
+
+  def at_least_one_item
+    if self.items.select(&:valid?).empty?
+      errors.add(
+        :_, 'At least one question must exist in order to create a form.'
+      )
+    end
+  end
 end
+

--- a/app/views/additional_details/questionnaires/_form.html.haml
+++ b/app/views/additional_details/questionnaires/_form.html.haml
@@ -4,6 +4,12 @@
   .panel-body
     = hidden_field_tag 'service_id', service.id
     = form_for [service, :additional_details, questionnaire], html: { class: 'form-horizontal questionnaire-form' } do |f|
+      - if questionnaire.errors.any?
+        .alert.alert-danger
+          %ul.list-unstyled
+            - questionnaire.errors.full_messages.each do |msg|
+              %li
+                = msg
       .form-group
         = f.label :name, 'Form Name', class: 'col-sm-2 control-label'
         .col-sm-10

--- a/spec/features/additional_details/user_should_see_error_when_no_questions_in_form_builder_spec.rb
+++ b/spec/features/additional_details/user_should_see_error_when_no_questions_in_form_builder_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'User should see error - no questions created', js: true do
+  let_there_be_lane
+  scenario 'successfully' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+
+    click_button 'Create Questionnaire'
+
+    expect(Questionnaire.count).to eq 0
+    expect(page).to have_content(
+      'At least one question must exist in order to create a form.')
+  end
+
+  scenario 'successfully - fills out name' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+
+    fill_in 'questionnaire_name', with: 'New Questionnaire'
+    click_button 'Create Questionnaire'
+
+    expect(page).to have_content(
+      'At least one question must exist in order to create a form.')
+  end
+
+  scenario 'successfully' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+    fill_in 'questionnaire_name', with: 'New Questionnaire'
+    fill_in 'questionnaire_items_attributes_0_content', with: 'What is your favorite color?'
+    select 'Radio Button', from: 'questionnaire_items_attributes_0_item_type'
+    fill_in 'questionnaire_items_attributes_0_item_options_attributes_0_content', with: 'Green'
+    click_link 'Add another Option'
+    fill_in 'questionnaire_items_attributes_0_item_options_attributes_1_content', with: 'Red'
+
+    check 'questionnaire_items_attributes_0_required'
+
+    click_button 'Create Questionnaire'
+
+    expect(current_path).to eq service_additional_details_questionnaires_path(service)
+    expect(Questionnaire.count).to eq 1
+    expect(page).not_to have_content(
+      'At least one question must exist in order to create a form.'
+    )
+  end
+end
+

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe Questionnaire, type: :model do
   it { is_expected.to accept_nested_attributes_for(:items) }
 
   it { is_expected.to validate_presence_of(:name) }
+
+  describe 'check the length of association' do
+    it 'should be invalid if it has no items' do
+      questionnaire = build(:questionnaire)
+
+      result = questionnaire.valid?
+
+      expect(result).to eq false
+      expect(questionnaire.errors[:_]).to include(
+        'At least one question must exist in order to create a form.'
+      )
+    end
+  end
 end
+


### PR DESCRIPTION
An error message is needed in the "form functionality form builder"
page. When no content/questions have been added to the form, and you
click "Create Questionnaire," no error message occurs. Added an
error stating "at least one question must exist in order to create a
form."[#139040143]