### PR TITLE
wth - Investigate 4 Columns in SR Table

### DIFF
--- a/app/api/v1/entities/full.rb
+++ b/app/api/v1/entities/full.rb
@@ -186,13 +186,9 @@ module V1
 
     expose  :protocol_id,
             :status,
-            :approved,
-            :subject_count
+            :approved
 
     with_options(format_with: :iso_timestamp) do
-      expose :consult_arranged_date
-      expose :pppv_complete_date
-      expose :pppv_in_process_date
       expose :submitted_at
     end
   end

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -61,9 +61,6 @@ class ServiceRequest < ActiveRecord::Base
   attr_accessible :status
   attr_accessible :notes
   attr_accessible :approved
-  attr_accessible :consult_arranged_date
-  attr_accessible :pppv_complete_date
-  attr_accessible :pppv_in_process_date
   attr_accessible :submitted_at
   attr_accessible :line_items_attributes
   attr_accessible :sub_service_requests_attributes
@@ -488,7 +485,6 @@ class ServiceRequest < ActiveRecord::Base
         arm = p.arms.create(
           name: 'Screening Phase',
           visit_count: 1,
-          subject_count: 1,
           new_with_draft: true)
         self.per_patient_per_visit_line_items.each do |li|
           arm.create_line_items_visit(li)

--- a/db/migrate/20170209152118_remove_columns_from_service_requests.rb
+++ b/db/migrate/20170209152118_remove_columns_from_service_requests.rb
@@ -1,0 +1,8 @@
+class RemoveColumnsFromServiceRequests < ActiveRecord::Migration
+  def change
+    remove_column :service_requests, :subject_count, :integer
+    remove_column :service_requests, :consult_arranged_date, :datetime
+    remove_column :service_requests, :pppv_complete_date, :datetime
+    remove_column :service_requests, :pppv_in_process_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118151049) do
+ActiveRecord::Schema.define(version: 20170209152118) do
 
   create_table "admin_rates", force: :cascade do |t|
     t.integer  "line_item_id", limit: 4
@@ -357,6 +357,9 @@ ActiveRecord::Schema.define(version: 20170118151049) do
     t.string   "email",                        limit: 255
     t.string   "last_name",                    limit: 255
     t.string   "first_name",                   limit: 255
+    t.string   "institution",                  limit: 255
+    t.string   "college",                      limit: 255
+    t.string   "department",                   limit: 255
     t.string   "era_commons_name",             limit: 255
     t.string   "credentials",                  limit: 255
     t.string   "subspecialty",                 limit: 255
@@ -913,10 +916,6 @@ ActiveRecord::Schema.define(version: 20170118151049) do
     t.integer  "protocol_id",             limit: 4
     t.string   "status",                  limit: 255
     t.boolean  "approved"
-    t.integer  "subject_count",           limit: 4
-    t.datetime "consult_arranged_date"
-    t.datetime "pppv_complete_date"
-    t.datetime "pppv_in_process_date"
     t.datetime "submitted_at"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false

--- a/spec/api/v1/service_requests/get_service_request_spec.rb
+++ b/spec/api/v1/service_requests/get_service_request_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
 
@@ -82,7 +82,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id', 'sub_service_requests', 'line_items', 'protocol').
                                 sort
 

--- a/spec/api/v1/service_requests/get_service_requests_spec.rb
+++ b/spec/api/v1/service_requests/get_service_requests_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
 
@@ -88,7 +88,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id', 'sub_service_requests', 'line_items', 'protocol').
                                 sort
 

--- a/spec/api/v1/service_requests/get_service_requests_with_ids_spec.rb
+++ b/spec/api/v1/service_requests/get_service_requests_with_ids_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
 
@@ -94,7 +94,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service_request).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'original_submitted_date', "consult_arranged_date", "pppv_complete_date", "pppv_in_process_date", "subject_count"].include?(key) }.
                                 push('callback_url', 'sparc_id', 'sub_service_requests', 'line_items', 'protocol').
                                 sort
 

--- a/spec/controllers/line_items/put_update_spec.rb
+++ b/spec/controllers/line_items/put_update_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe LineItemsController, type: :controller do
 
       it 'should update service request status' do
         protocol  = create(:protocol_without_validations, primary_pi: logged_in_user, funding_status: 'funded', funding_source: 'federal')
-        sr        = create(:service_request_without_validations, protocol: protocol, status: 'on_hold', subject_count: 3)
+        sr        = create(:service_request_without_validations, protocol: protocol, status: 'on_hold')
         org       = create(:organization)
         ssr       = create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'on_hold')
         service   = create(:service, one_time_fee: true)

--- a/spec/support/capybara_support.rb
+++ b/spec/support/capybara_support.rb
@@ -168,7 +168,7 @@ module CapybaraSupport
 
     project = FactoryGirl.create(:protocol_without_validations)
 
-    service_request = FactoryGirl.create(:service_request_without_validations, protocol_id: project.id, status: "draft", subject_count: 2)
+    service_request = FactoryGirl.create(:service_request_without_validations, protocol_id: project.id, status: "draft")
 
     sub_service_request = create(:sub_service_request, service_request_id: service_request.id, organization_id: program.id,status: "draft", service_requester_id: Identity.find_by_ldap_uid("jug2@musc.edu").id)
 


### PR DESCRIPTION
There are 4 columns in the service_requests table: subject_count,
consult_arranged_date, pppv_complete_date, pppv_in_process_date that
doesn't seem to have corresponding fields in the front-end, and have
very few data (i.e. only 1 record for pppv_in_process_date and
pppv_complete_date).

These columns are not necessary anymore and generated migration to
remove them. Fixed specs in the process. [#139044137]