### PR TITLE
wth - Step 4: Added Protocol Notes not showing up

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -155,6 +155,8 @@ class ServiceRequestsController < ApplicationController
   end
 
   def review
+    @notable_type = 'Protocol'
+    @notable_id = @service_request.protocol_id
     @tab          = 'calendar'
     @review       = true
     @portal       = false

--- a/app/views/service_requests/review.html.haml
+++ b/app/views/service_requests/review.html.haml
@@ -28,7 +28,7 @@
     = render 'service_requests/review/protocol_information', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/authorized_users', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/documents', service_request: @service_request, protocol: @service_request.protocol
-    = render 'service_requests/review/notes', service_request: @service_request, notable_id: @service_request.id, notable_type: 'ServiceRequest'
+    = render 'service_requests/review/notes', service_request: @service_request, notable_id: @notable_id, notable_type: @notable_type
     = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, admin: @admin, review: @review, merged: @merged, consolidated: @consolidated
 = render 'service_requests/navigation/footer', service_request: @service_request, css_class: @css_class, back: @back, forward: @forward
 

--- a/spec/features/review/user_should_see_notes_spec.rb
+++ b/spec/features/review/user_should_see_notes_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'User should see notes', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
+
+  before :each do
+    institution   = create(:institution, name: "Institution")
+    provider      = create(:provider, name: "Provider", parent: institution)
+    program       = create(:program, name: "Program", parent: provider, process_ssrs: true)
+    service       = create(:service_with_pricing_map, name: 'Brain Removal')
+    @protocol     = create(:protocol_federally_funded, type: 'Study', primary_pi: jug2)
+    @sr           = create(:service_request_without_validations, status: 'first_draft', protocol: @protocol)
+    ssr           = create(:sub_service_request_without_validations, service_request: @sr, organization: program, status: 'first_draft')
+                    create(:line_item, service_request: @sr, sub_service_request: ssr, service: service)
+                    create(:arm, protocol: @protocol, visit_count: 1)
+    visit document_management_service_request_path(@sr)
+    wait_for_javascript_to_finish
+  end
+
+  scenario 'User creates note and then views it on Review page' do
+    click_button 'Add a Note'
+    expect(page).to have_css('#new-note-modal')
+    fill_in 'note_body', with: 'test'
+    click_button 'Add'
+    wait_for_javascript_to_finish
+    expect(page).to have_css('td.note', text: 'test')
+    click_link 'Save and Continue'
+    expect(page).to have_content 'test'
+  end
+end


### PR DESCRIPTION
On SPARCRequest, the added protocol notes on Step 3 are not showing up
on Step 4 (summary) page, although the data is stored correctly and the
notes show up on SPARCDashboard.

This was caused by the Notable type and ID being set to 'ServiceRequest'
and the ID of the ServiceRequest, when it should've been to the
Protocol. [#139499703]