### PR TITLE
wth - Move the Ruby Racer gem to Production group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'savon', '~> 2.2.0'
 gem 'simplecov', require: false, group: :test
 gem 'sinatra'
 gem 'surveyor', :git => 'https://github.com/sparc-request/surveyor.git', branch: 'rails4'
-gem 'therubyracer', '0.10.2', :platforms => :ruby
+gem 'therubyracer', '0.10.2', :platforms => :ruby, group: :production
 gem 'twitter-typeahead-rails'
 gem 'uglifier', '>= 1.0.3'
 gem 'whenever', require: false


### PR DESCRIPTION
Our current locked version of the RubyRacer gem causes issues with the
setup of the application. Since this gem is only needed for our
production server environment as the JavaScript Runtime, we don't need
to require it along with our development and test gemsets.[#139571923]