### PR TITLE
wth - Do not hide prices

### DIFF
--- a/app/helpers/service_calendar_helper.rb
+++ b/app/helpers/service_calendar_helper.rb
@@ -27,7 +27,7 @@ module ServiceCalendarHelper
   def display_service_rate line_item
     full_rate = line_item.service.displayed_pricing_map.full_rate
 
-    full_rate < line_item.applicable_rate ? "N/A" : currency_converter(full_rate)
+    currency_converter(full_rate)
   end
 
   def display_your_cost line_item


### PR DESCRIPTION
On SPARCDashboard and SPARCRequest, if the "Service Rate" is smaller
than "You Cost" (which could have happened because of admin edit
pricing, or setup that way in SPARCCatalog), the "Service Rate" is
showing up as "N/A". Displaying the true "Service Rate" no matter
what. [#139393951]