### PR TITLE
wth - Step 3: Default Document Access to every Service Provider

### DIFF
--- a/app/views/documents/_document_form.html.haml
+++ b/app/views/documents/_document_form.html.haml
@@ -49,7 +49,7 @@
             .form-group
               = form.label :org_ids, t(:documents)[:form_fields][:access], class: 'col-sm-4 control-label'
               .col-sm-7
-                = select_tag :org_ids, options_from_collection_for_select(document.protocol.organizations.distinct.sort_by(&:name), :id, :name, document.sub_service_requests.map(&:organization_id)), class: 'form-control selectpicker', multiple: true
+                = select_tag :org_ids, document_org_access_collection(document, action_name), class: 'form-control selectpicker', multiple: true
       .modal-footer
         .center-block
           %button.btn.btn-default{ type: 'button', data: { dismiss: 'modal' } }


### PR DESCRIPTION
On SPARCRequest Step 3, I defaulted the document access to every
service providers on the protocol and display the name of the
organization, so that it behaves consistently with
SPARCDashboard.[#139500987]