### PR TITLE
wth - Move Research Medications Organization to MUHA Institution

### DIFF
--- a/lib/tasks/move_rm_medications_to_muha.rake
+++ b/lib/tasks/move_rm_medications_to_muha.rake
@@ -1,0 +1,8 @@
+namespace :data do
+  task :move_rm_medications_to_muha => :environment do
+    muha = Organization.find_by_name('MUHA-Medical University Hospital Authority')
+    rm_medications = Organization.find_by_name('Research Medications/Drugs')
+
+    rm_medications.update_attribute(:parent_id, muha.id)
+  end
+end


### PR DESCRIPTION
Moved the provider organization "Research medications/Drugs"
(organizations.id = 68) along with its two children orgs (77 and 80) to
be under institution organization "MUHA-Medical University Hospital
Authority" (organizations.id = 181) instead of the current
institution.[#139557055]