### PR TITLE
wth - Display RMID - View Details

### DIFF
--- a/app/views/dashboard/protocols/_summary.html.haml
+++ b/app/views/dashboard/protocols/_summary.html.haml
@@ -32,6 +32,16 @@
       = edit_protocol_button_display(protocol, permission_to_edit)
     .clearfix
   .panel-body#protocol-summary.text-left
+    - if RESEARCH_MASTER_ENABLED
+      .row
+        .col-sm-2
+          %label
+            = I18n.t('protocols.summary.research_master_id')
+        .col-sm-10
+          - if protocol.research_master_id.nil?
+            = I18n.t('protocols.summary.na_research_master_id')
+          - else
+            = protocol.research_master_id
     .row
       .col-sm-2
         %label

--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -28,6 +28,16 @@
         = link_to I18n.t('protocols.edit', protocol_type: protocol_type), edit_protocol_path(protocol, srid: service_request.id), class: 'btn btn-warning edit-protocol-information-button'
     .clearfix
   .panel-body#protocol-summary.text-left
+    - if RESEARCH_MASTER_ENABLED
+      .row
+        .col-sm-3
+          %label
+            = I18n.t('protocols.summary.research_master_id')
+        .col-sm-9
+          - if protocol.research_master_id.nil?
+            = I18n.t('protocols.summary.na_research_master_id')
+          - else
+            = protocol.research_master_id
     .row
       .col-sm-3
         %label

--- a/app/views/protocols/view_details/_study_information.html.haml
+++ b/app/views/protocols/view_details/_study_information.html.haml
@@ -28,10 +28,10 @@
         %tr.row
           %td
             %label.col-lg-4
-              = "Research Master ID:"
+              = t(:protocols)[:summary][:research_master_id]
             .col-lg-8
               - if protocol.research_master_id.nil?
-                = 'Not Available'
+                = t(:protocols)[:summary][:na_research_master_id]
               - else
                 = protocol.research_master_id
       %tr.row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,6 +291,8 @@ en:
       sponsor: "Sponsor Name:"
       funding_source: "Funding Source:"
       potential_source: "Potential Funding Source:"
+      research_master_id: "Research Master ID:"
+      na_research_master_id: 'Not Available'
     view_details:
       button: "View %{protocol_type} Details"
       header: "%{protocol_type} Details: #%{protocol_id}"

--- a/spec/features/dashboard/protocols/user_should_see_rm_id_displayed_spec.rb
+++ b/spec/features/dashboard/protocols/user_should_see_rm_id_displayed_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe 'User should see RM ID displayed', js: true do
     expect(page).to have_content 'Research Master ID: 1'
   end
 
+  scenario 'successfully' do
+    protocol = create(
+      :unarchived_study_without_validations,
+      primary_pi: user,
+      research_master_id: 1
+    )
+
+    visit dashboard_protocol_path(protocol)
+    expect(page).to have_content "Research Master ID: #{protocol.research_master_id}"
+  end
+
   scenario 'successfully - No RMID' do
     protocol = create(
       :unarchived_study_without_validations,
@@ -78,6 +89,44 @@ RSpec.describe 'User should see RM ID displayed', js: true do
 
     expect(page).to have_content 'Research Master ID: 1'
   end
+
+  scenario 'successfully - Step 1' do
+    institution = create(:institution, name: "Institution")
+    provider    = create(:provider, name: "Provider", parent: institution)
+    program     = create(
+      :program, name: "Program", parent: provider, process_ssrs: true
+    )
+    service     = create(
+      :service, name: "Service", abbreviation: "Service", organization: program
+    )
+    protocol = create(
+      :unarchived_study_without_validations,
+      primary_pi: user,
+      research_master_id: 1
+    )
+    sr = create(
+      :service_request_without_validations,
+      status: 'first_draft',
+      protocol: protocol
+    )
+    ssr = create(
+      :sub_service_request_without_validations,
+      service_request: @sr, organization: program, status: 'first_draft'
+    )
+    create(
+      :line_item,
+      service_request: sr, sub_service_request: ssr, service: service
+    )
+    create(:arm, protocol: protocol, visit_count: 1)
+    create(
+      :subsidy_map, organization: program, max_dollar_cap: 100, max_percentage: 100
+    )
+
+    visit protocol_service_request_path(sr)
+
+    expect(page).to have_content 'Research Master ID: 1'
+  end
+
 
   scenario 'successfully - Step 1' do
     institution = create(:institution, name: "Institution")


### PR DESCRIPTION
On both SPARCRequest Step 1 and SPARCDashboard, I added the display
of Research Master ID in the "View Study/Project Details" popup window,
as well as in the "Study Summary" section. To handle potential nil
values, created Null object which we can add to in the future.
[#139008535]