### PR TITLE
wth -  Remove the Request/Approve Services User Right and Migrate

### DIFF
--- a/app/models/project_role.rb
+++ b/app/models/project_role.rb
@@ -134,10 +134,6 @@ class ProjectRole < ActiveRecord::Base
     if role == 'business-grants-manager' and right == 'approve'
       return true
     end
-
-    if current_user == identity and role != 'pi' and role != 'primary-pi' and right == 'request'
-      return true
-    end
     return false
   end
 
@@ -151,7 +147,6 @@ class ProjectRole < ActiveRecord::Base
     case project_rights
     when "none"    then "Member Only"
     when "view"    then "View Rights"
-    when "request" then "Request/Approve Services"
     when "approve" then "Authorize/Change Study Charges"
     end
   end

--- a/app/views/associated_users/_user_form.html.haml
+++ b/app/views/associated_users/_user_form.html.haml
@@ -86,11 +86,6 @@
                     = t(:authorized_users)[:rights][:view]
               .radio
                 %label
-                  = form.radio_button :project_rights, "request", disabled: disable
-                  %span
-                    = t(:authorized_users)[:rights][:request]
-              .radio
-                %label
                   = form.radio_button :project_rights, "approve", disabled: disable
                   %span
                     = t(:authorized_users)[:rights][:approve]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,6 @@ en:
     rights:
       none: Member Only
       view: "View Rights"
-      request: "Request/Approve Services"
       approve: "Authorized/Change Study Charges"
     table_fields:
       name: "Full Name"

--- a/lib/tasks/upgrade_request_to_approve.rake
+++ b/lib/tasks/upgrade_request_to_approve.rake
@@ -1,0 +1,11 @@
+namespace :data do
+  task upgrade_request_to_approve: :environment do
+    project_roles = ProjectRole.where(
+      project_rights: 'request'
+    )
+
+    project_roles.each do |pr|
+      pr.update_attribute(:project_rights, 'approve')
+    end
+  end
+end

--- a/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
+++ b/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
@@ -257,7 +257,7 @@ RSpec.feature 'User wants to add an authorized user', js: true do
 
   def when_i_fill_out_the_required_fields
     when_i_set_the_role_to('Co-Investigator')
-    @page.authorized_user_modal.request_rights.click
+    @page.authorized_user_modal.approve_rights.click
   end
 
   def when_i_set_the_role_and_credentials_to_other
@@ -293,8 +293,8 @@ RSpec.feature 'User wants to add an authorized user', js: true do
   end
 
   def then_i_should_see_the_user_has_been_added
-    @page.wait_for_authorized_users(text: /Jane Doe.*Co-Investigator.*Request\/Approve Services/)
-    expect(@page).to have_authorized_users(text: /Jane Doe.*Co-Investigator.*Request\/Approve Services/)
+    @page.wait_for_authorized_users(text: /Jane Doe.*Co-Investigator.*Authorize/)
+    expect(@page).to have_authorized_users(text: /Jane Doe.*Co-Investigator.*Authorize/)
   end
 
   def then_i_should_see_the_warning_message

--- a/spec/features/dashboard/protocols/user_should_no_longer_see_request_approve_services_spec.rb
+++ b/spec/features/dashboard/protocols/user_should_no_longer_see_request_approve_services_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'User should no longer see request/approve auth user', js: true do
+  let!(:user) do
+    create(:identity,
+           last_name: "Doe",
+           first_name: "John",
+           ldap_uid: "johnd",
+           email: "johnd@musc.edu",
+           password: "p4ssword",
+           password_confirmation: "p4ssword",
+           approved: true
+          )
+  end
+
+  fake_login_for_each_test('johnd')
+
+  scenario 'successfully - dashboard' do
+    protocol = create(
+      :unarchived_study_without_validations,
+      primary_pi: user,
+      research_master_id: 1
+    )
+
+    visit dashboard_protocol_path(protocol)
+    find('.edit-associated-user-button').click
+    wait_for_javascript_to_finish
+
+    expect(page).not_to have_css '#project_role_project_rights_request'
+  end
+
+  scenario 'successfully - Step 1' do
+    institution = create(:institution, name: "Institution")
+    provider    = create(:provider, name: "Provider", parent: institution)
+    program     = create(
+      :program, name: "Program", parent: provider, process_ssrs: true
+    )
+    service     = create(
+      :service, name: "Service", abbreviation: "Service", organization: program
+    )
+    protocol = create(
+      :unarchived_study_without_validations,
+      primary_pi: user,
+      research_master_id: 1
+    )
+    sr = create(
+      :service_request_without_validations,
+      status: 'first_draft',
+      protocol: protocol
+    )
+    ssr = create(
+      :sub_service_request_without_validations,
+      service_request: @sr, organization: program, status: 'first_draft'
+    )
+    create(
+      :line_item,
+      service_request: sr, sub_service_request: ssr, service: service
+    )
+    create(:arm, protocol: protocol, visit_count: 1)
+    create(
+      :subsidy_map, organization: program, max_dollar_cap: 100, max_percentage: 100
+    )
+
+    visit protocol_service_request_path(sr)
+    find('.edit-associated-user-button').click
+    wait_for_javascript_to_finish
+
+    expect(page).not_to have_css '#project_role_project_rights_request'
+  end
+end
+

--- a/spec/models/project_role/project_role_spec.rb
+++ b/spec/models/project_role/project_role_spec.rb
@@ -93,11 +93,6 @@ RSpec.describe 'Project Role' do
       expect(@project_role.should_select?('approve', user)).to eq(true)
     end
 
-    it "should return true if current user is on project role, role != 'pi', and right == 'request'" do
-      @project_role.update_attributes(role: 'mentor')
-      expect(@project_role.should_select?('request', user)).to eq(true)
-    end
-
     it "should return false if previous conditions are not met" do
       expect(@project_role.should_select?('request', user)).to eq(false)
       @project_role.update_attributes(role: 'mentor')
@@ -115,11 +110,6 @@ RSpec.describe 'Project Role' do
     it "should display 'View Rights' when project right is 'view'" do
       @project_role.update_attributes(project_rights: 'view')
       expect(@project_role.display_rights).to eq("View Rights")
-    end
-
-    it "should display 'Request/Approve Services' when project right is 'request'" do
-      @project_role.update_attributes(project_rights: 'request')
-      expect(@project_role.display_rights).to eq("Request/Approve Services")
     end
 
     it "should display 'Authorize/Change Study Charges' when project right is 'approve'" do

--- a/spec/support/pages/dashboard/protocols/show_page.rb
+++ b/spec/support/pages/dashboard/protocols/show_page.rb
@@ -62,7 +62,6 @@ module Dashboard
         # rights radio buttons
         element :none_rights, "#project_role_project_rights_none"
         element :view_rights, "#project_role_project_rights_view"
-        element :request_rights, "#project_role_project_rights_request"
         element :approve_rights, "#project_role_project_rights_approve"
 
         # generic matcher for any dropdown choices


### PR DESCRIPTION
Historical Data

On SPARCRequest Step 1 and SPARCDashboard Authorized Users table,
I removed the 3rd option for "Request/Approve
Services" user rights, because it has not been used.

For historical data that has this type of right
(project_roles.project_rights = request), I migrated them to have
the highest user right instead (project_roles.project_rights = approve).
[#139421767]