### PR TITLE
wth - Form Builder validations

### DIFF
--- a/app/views/additional_details/questionnaires/_form.html.haml
+++ b/app/views/additional_details/questionnaires/_form.html.haml
@@ -7,9 +7,10 @@
       - if questionnaire.errors.any?
         .alert.alert-danger
           %ul.list-unstyled
-            - questionnaire.errors.full_messages.each do |msg|
-              %li
-                = msg
+            - questionnaire.errors.messages.values.each do |msg|
+              - msg.each do |m|
+                %li
+                  = m
       .form-group
         = f.label :name, 'Form Name', class: 'col-sm-2 control-label'
         .col-sm-10

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,16 @@ en:
   # ACTIVERECORD #
   ################
   activerecord:
+    errors:
+      models:
+        item:
+          attributes:
+            content:
+              blank: "Content can't be blank"
+        questionnaire:
+          attributes:
+            name:
+              blank: "Name can't be blank"
     attributes:
       arm:
         name: "Arm Name"


### PR DESCRIPTION
An error message is needed in the "form functionality form builder"
page. When no content/questions have been added to the form, and you
click "Create Questionnaire," no error message occurs. Added an
error stating "at least one question must exist in order to create a
form."[#139040143]

Validation language change.