### PR TITLE
wth - (SPARCCatalog) Form Functionality Form Builder Part II

### DIFF
--- a/app/assets/javascripts/additional_details/item_options.coffee
+++ b/app/assets/javascripts/additional_details/item_options.coffee
@@ -8,16 +8,24 @@ $ ->
     itemId = $(this).data('item-form-id')
     if showOptions($(this).val(), needOptions)
       $(".item-options[data-item-form-id=#{itemId}]").removeClass('hidden')
+      $.each $(".set-validate-content[data-item-form-id=#{itemId}]"), (key, value) ->
+        $(value).val('true')
     else
       $(".item-options[data-item-form-id=#{itemId}]").addClass('hidden')
+      $.each $(".set-validate-content[data-item-form-id=#{itemId}]"), (key, value) ->
+        $(value).val('false')
 
   $(document).on 'fields_added.nested_form_fields', (event, param) ->
+    $('.select-type').trigger('change')
     $('.select-type').on 'change', ->
       itemId = $(this).data('item-form-id')
       if showOptions($(this).val(), needOptions)
         $(".item-options[data-item-form-id=#{itemId}]").removeClass('hidden')
       else
         $(".item-options[data-item-form-id=#{itemId}]").addClass('hidden')
+
+  $(document).on 'fields_removed.nested_form_fields', (event, param) ->
+    $('.select-type').trigger('change')
 
 
   $.each $('.select-type :selected'), (key, value) ->

--- a/app/models/item_option.rb
+++ b/app/models/item_option.rb
@@ -1,3 +1,5 @@
 class ItemOption < ActiveRecord::Base
   belongs_to :item
+
+  validates :content, presence: true, if: :validate_content?
 end

--- a/app/views/additional_details/questionnaires/_form.html.haml
+++ b/app/views/additional_details/questionnaires/_form.html.haml
@@ -31,6 +31,9 @@
           %hr
           - i.object.item_options.build unless i.object.item_options.any?
           = i.nested_fields_for :item_options, html: { class: 'form-horizontal' } do |io|
+            = io.hidden_field :validate_content, value: false,
+              class: 'set-validate-content',
+              data: { item_form_id: '__nested_field_for_replace_with_index__' }
             .col-sm-offset-2
               .form-group
                 = io.label :content, class: 'col-sm-2 control-label'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,10 @@ en:
           attributes:
             name:
               blank: "Name can't be blank"
+        item_option:
+          attributes:
+            content:
+              blank: "Content can't be blank"
     attributes:
       arm:
         name: "Arm Name"

--- a/db/migrate/20170213212738_add_validate_content_to_item_options.rb
+++ b/db/migrate/20170213212738_add_validate_content_to_item_options.rb
@@ -1,0 +1,5 @@
+class AddValidateContentToItemOptions < ActiveRecord::Migration
+  def change
+    add_column :item_options, :validate_content, :boolean, after: :content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209152118) do
+ActiveRecord::Schema.define(version: 20170213212738) do
 
   create_table "admin_rates", force: :cascade do |t|
     t.integer  "line_item_id", limit: 4
@@ -427,10 +427,11 @@ ActiveRecord::Schema.define(version: 20170209152118) do
   add_index "ip_patents_info", ["protocol_id"], name: "index_ip_patents_info_on_protocol_id", using: :btree
 
   create_table "item_options", force: :cascade do |t|
-    t.string   "content",    limit: 255
-    t.integer  "item_id",    limit: 4
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "content",          limit: 255
+    t.boolean  "validate_content"
+    t.integer  "item_id",          limit: 4
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
   add_index "item_options", ["item_id"], name: "index_item_options_on_item_id", using: :btree

--- a/spec/factories/item_option.rb
+++ b/spec/factories/item_option.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :item_option do
+    content 'text'
+    validate_content true
+    item_id nil
+  end
+end

--- a/spec/features/additional_details/user_should_validation_errors_item_content_spec.rb
+++ b/spec/features/additional_details/user_should_validation_errors_item_content_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'User should see validation errors on item content', js: true do
+  scenario 'successfully' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+    fill_in 'questionnaire_name', with: 'New Questionnaire'
+    fill_in 'questionnaire_items_attributes_0_content', with: 'What is your favorite color?'
+    select 'Radio Button', from: 'questionnaire_items_attributes_0_item_type'
+
+    check 'questionnaire_items_attributes_0_required'
+
+    click_button 'Create Questionnaire'
+
+    expect(page).to have_content "Content can't be blank"
+  end
+
+  scenario 'successfully' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+    fill_in 'questionnaire_name', with: 'New Questionnaire'
+    fill_in 'questionnaire_items_attributes_0_content', with: 'What is your favorite color?'
+    select 'Radio Button', from: 'questionnaire_items_attributes_0_item_type'
+    fill_in 'questionnaire_items_attributes_0_item_options_attributes_0_content', with: 'Green'
+    click_link 'Add another Option'
+
+    check 'questionnaire_items_attributes_0_required'
+
+    click_button 'Create Questionnaire'
+
+    expect(page).to have_content "Content can't be blank"
+  end
+
+  scenario 'successfully' do
+    service = create(:service, :with_ctrc_organization)
+    visit new_service_additional_details_questionnaire_path(service)
+    fill_in 'questionnaire_name', with: 'New Questionnaire'
+    fill_in 'questionnaire_items_attributes_0_content', with: 'What is your favorite color?'
+    select 'Radio Button', from: 'questionnaire_items_attributes_0_item_type'
+    fill_in 'questionnaire_items_attributes_0_item_options_attributes_0_content', with: 'Green'
+    click_link 'Add another Option'
+    fill_in 'questionnaire_items_attributes_0_item_options_attributes_1_content', with: 'Red'
+
+    check 'questionnaire_items_attributes_0_required'
+
+    click_button 'Create Questionnaire'
+
+    expect(page).not_to have_content "Content can't be blank"
+    expect(current_path).to eq service_additional_details_questionnaires_path(service)
+    expect(Questionnaire.count).to eq 1
+  end
+end
+

--- a/spec/models/item_option_spec.rb
+++ b/spec/models/item_option_spec.rb
@@ -2,4 +2,17 @@ require 'rails_helper'
 
 RSpec.describe ItemOption, type: :model do
   it { is_expected.to belong_to(:item) }
+
+  it 'should validate presence if validate_content is true' do
+    item_option = build(:item_option, content: nil, validate_content: true)
+
+    expect(item_option).not_to be_valid
+  end
+
+  it 'should carry along if validate_content is false' do
+    item_option = build(:item_option, content: nil, validate_content: false)
+
+    expect(item_option).to be_valid
+  end
 end
+


### PR DESCRIPTION
In SPARCCatalog Form functionality, if a user selects an "item type"
that populates a dropdown in which "content" is logically driven,
I included an error message that states "Content can't be blank."
[#139729675]