### PR TITLE
wth - (SPARCCatalog) Form Functionality Form Builder Part II

### DIFF
--- a/app/assets/javascripts/additional_details/item_options.coffee
+++ b/app/assets/javascripts/additional_details/item_options.coffee
@@ -4,7 +4,7 @@ $ ->
   showOptions = (selection, array) ->
     $.inArray(selection, array) > -1
 
-  $('.select-type').on 'change', ->
+  $(document).on 'change', '.select-type', ->
     itemId = $(this).data('item-form-id')
     if showOptions($(this).val(), needOptions)
       $(".item-options[data-item-form-id=#{itemId}]").removeClass('hidden')


### PR DESCRIPTION
JS was only running when interacting with the first select box, however
was losing scope when there were two or more selects. Telling JS to
listen to document rather than element fixes this bug. [#139729675]