### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Display Research Master ID in

### DIFF
--- a/app/views/dashboard/protocols/_summary.html.haml
+++ b/app/views/dashboard/protocols/_summary.html.haml
@@ -32,7 +32,7 @@
       = edit_protocol_button_display(protocol, permission_to_edit)
     .clearfix
   .panel-body#protocol-summary.text-left
-    - if RESEARCH_MASTER_ENABLED
+    - if RESEARCH_MASTER_ENABLED && protocol.is_study?
       .row
         .col-sm-2
           %label

--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -28,7 +28,7 @@
         = link_to I18n.t('protocols.edit', protocol_type: protocol_type), edit_protocol_path(protocol, srid: service_request.id), class: 'btn btn-warning edit-protocol-information-button'
     .clearfix
   .panel-body#protocol-summary.text-left
-    - if RESEARCH_MASTER_ENABLED
+    - if RESEARCH_MASTER_ENABLED && protocol.is_study?
       .row
         .col-sm-3
           %label


### PR DESCRIPTION
"View Study/Project Details" and "Study Summary"

This fixes error where Research Master ID was being displayed in the
Project Summaries on Proper and Dashboard. Only should be on Studies. [#139008535]