### PR TITLE
wth - (SPARCReport) Service Request Report Adding Coumn

### DIFF
--- a/app/reports/service_requests.rb
+++ b/app/reports/service_requests.rb
@@ -37,7 +37,8 @@ class ServiceRequestsReport < ReportingModule
       Core => {:field_type => :select_tag, :dependency => '#program_id', :dependency_id => 'parent_id'},
       "Tags" => {:field_type => :text_field_tag},
       "Current Status" => {:field_type => :check_box_tag, :for => 'status', :multiple => AVAILABLE_STATUSES},
-      "Show APR Data" => {:field_type => :check_box_tag, :for => 'apr_data', :multiple => {"irb" => "IRB", "iacuc" => "IACUC"}}
+      "Show APR Data" => {:field_type => :check_box_tag, :for => 'apr_data', :multiple => {"irb" => "IRB", "iacuc" => "IACUC"}},
+      "Show SPARCFulfillment Information" => {:field_type => :check_box_tag, :for => 'fulfillment_info' }
     }
   end
 
@@ -97,6 +98,10 @@ class ServiceRequestsReport < ReportingModule
         attrs["IACUC Approval Date"] = "service_request.try(:protocol).try(:vertebrate_animals_info).try(:iacuc_approval_date).try(:strftime, \"%D\")"
         attrs["IACUC Expiration Date"] = "service_request.try(:protocol).try(:vertebrate_animals_info).try(:iacuc_expiration_date).try(:strftime, \"%D\")"
       end
+    end
+
+    if params[:fulfillment_info]
+      attrs["Sent to SPARCFulfillment"] = "service_request.sub_service_requests.in_work_fulfillment.any? ? 'Yes' : 'No'"
     end
 
     attrs

--- a/app/views/reports/_setup.html.haml
+++ b/app/views/reports/_setup.html.haml
@@ -124,7 +124,7 @@
           - multiple = options[:multiple]
           - grouping = options[:grouping]
           - selected = options[:selected] || []
-          - default_classes = "required_field" if options[:required]
+          - default_classes = options[:required] ? "required_field" : ""
           - name = options[:for] ? "report[#{options[:for]}]" : "report[#{field.name.underscore}_id]"
           - name += "[]" if multiple
           %label.col-sm-3.control-label= field_label


### PR DESCRIPTION
1). Added a "Show SPARCFulfillment Information" checkbox on the filter
page. Had to change default_classes variable to ternary because this will not be a required field.

2). When the user checks the "Show SPARCFulfillment Information"
checkbox, a "Sent to SPARCFulfillment" column is added to the generated
report showing whether the corresponding SSR has been pushed to
Fulfillment.

[#139974195]