### PR TITLE
In CM, if a service threw an error on update, the shared update js th…

### DIFF
--- a/app/views/catalog_manager/shared/_update.js.haml
+++ b/app/views/catalog_manager/shared/_update.js.haml
@@ -23,7 +23,7 @@
   :plain
     $('#flash').hide();
     $('#flash').html("There were errors saving #{escape_javascript(@entity.name)}.");
-    Sparc.catalog.handle_ajax_errors("#{escape_javascript(@entity_errors)}", "#{@entity.type}")
+    Sparc.catalog.handle_ajax_errors("#{escape_javascript(@entity_errors)}", "#{@entity.class.name == 'Service' ? 'Service' : @entity.type}")
 
 - else
   :plain


### PR DESCRIPTION
…rew an error becuase services don't have a 'type' column. [#140095953]