### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Tooltips: Step 1 Study Information

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -26,6 +26,15 @@ resetRmIdFields = (fields, value) ->
 
 $(document).ready ->
 
+  $(document).on 'click', '.exemption-radio', ->
+    type = $(this).data('type')
+    if type == 'ide'
+      $('.device-number').attr('data-original-title', 'Investigation Device Exemption (IDE) Number').tooltip('fixTitle')
+    else if type == 'hde'
+      $('.device-number').attr('data-original-title', 'Humanitarian Device Exemption (HDE) Number').tooltip('fixTitle')
+    else if type == 'hud'
+      $('.device-number').attr('data-original-title', 'Humanitarian Use Device (HUD) Number').tooltip('fixTitle')
+
   if $('.human-subjects:checkbox:checked').length > 0
     $('.rm-id').addClass('required-field')
     $('.has-human-subject-info').val('true')

--- a/app/views/dashboard/protocols/form/_project_fields.html.haml
+++ b/app/views/dashboard/protocols/form/_project_fields.html.haml
@@ -25,27 +25,34 @@
     .form-group.row
       = form.label :short_title, t(:protocols)[:projects][:information][:short_title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :short_title, class: 'form-control'
+        = form.text_field :short_title, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:short_title]
 
     .form-group.row
       = form.label :title, t(:protocols)[:projects][:information][:title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :title, class: 'form-control'
+        = form.text_field :title, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:title]
 
     .form-group.row#funding-status
       = form.label :funding_status, t(:protocols)[:projects][:information][:funding_status], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker project'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_status] do
+          = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker project'
   
     .form-group.row.funding_status_dependent.funded{ display_if(protocol.funding_status, "funded") }
       = form.label :funding_source, t(:protocols)[:projects][:information][:funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_source] do
+          = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :potential_funding_source, t(:protocols)[:projects][:information][:potential_funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:potential_funding_source] do
+          = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
 
     .form-group.row
       = form.label :brief_description, t(:protocols)[:projects][:information][:description], class: "col-lg-2 control-label"

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -22,16 +22,23 @@
 .form-group.row
   = form.label :selected_for_epic, t(:protocols)[:studies][:information][:push_to_epic], class: 'col-lg-2 control-label required'
   .col-lg-10
-    .btn-group#selected_for_epic_button{data: {toggle: "labels"}}
-      %label.radio-inline.btn.btn-default#study_selected_for_epic_true_button{ class: protocol.selected_for_epic? ? 'active' : ''}
-        = form.radio_button :selected_for_epic, 'true', id: "study_selected_for_epic_true", class: 'hidden'
-        = t(:constants)[:yes_select]
-      %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false ? 'active' : ''}
-        = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
-        = t(:constants)[:no_select]
+    = link_to 'javascript:void(0)',
+      data: { toggle: 'tooltip', placement: 'right' },
+      title: t(:protocols)[:tooltips][:epic] do
+      .btn-group#selected_for_epic_button{data: {toggle: "labels"}}
+        %label.radio-inline.btn.btn-default#study_selected_for_epic_true_button{ class: protocol.selected_for_epic? ? 'active' : ''}
+          = form.radio_button :selected_for_epic, 'true', id: "study_selected_for_epic_true", class: 'hidden'
+          = t(:constants)[:yes_select]
+        %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false ? 'active' : ''}
+          = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
+          = t(:constants)[:no_select]
 .form-group.row.selected_for_epic_dependent{ display_if(protocol.selected_for_epic) }
   = hidden_field_tag :updated_protocol_type, updated_protocol_type
-  = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: 'col-lg-2 control-label required'
+  = form.label :study_type_questions,
+    t(:protocols)[:studies][:information][:study_type_questions],
+    class: 'col-lg-2 control-label required',
+    data: { toggle: 'tooltip', placement: 'right' },
+    title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10
     = form.fields_for :study_type_answers, protocol.study_type_answers do |answer_form|
       - if answer_form.object.study_type_question.study_type_question_group.active

--- a/app/views/dashboard/protocols/form/study_form_sections/_research_involving.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_research_involving.html.haml
@@ -37,7 +37,9 @@
           .form-group.row.nct-number
             = hs_form.label :nct_number, t(:protocols)[:studies][:research_involving][:humans][:nct_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :nct_number, class: 'form-control'
+              = hs_form.text_field :nct_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: t(:protocols)[:tooltips][:nct_number]
 
           .form-group.row
             = hs_form.label :hr_number, t(:protocols)[:studies][:research_involving][:humans][:hr_number], class: 'col-lg-2 control-label'
@@ -47,7 +49,9 @@
           .form-group.row
             = hs_form.label :pro_number, t(:protocols)[:studies][:research_involving][:humans][:pro_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :pro_number, class: 'form-control'
+              = hs_form.text_field :pro_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: t(:protocols)[:tooltips][:pro_number]
 
           .form-group.row
             = hs_form.label :irb_of_record, t(:protocols)[:studies][:research_involving][:humans][:record_irb], class: 'col-lg-2 control-label'
@@ -120,7 +124,9 @@
           .form-group.row
             = ip_form.label :ind_number, t(:protocols)[:studies][:research_involving][:products][:ind_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = ip_form.text_field :ind_number, class: 'form-control'
+              = ip_form.text_field :ind_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: 'Investigational New Drug (IND) Number'
 
           .form-group.row#ind-on-hold-group{ display_if(!ip_form.object.ind_number.blank?) }
             = ip_form.label :ind_on_hold, t(:protocols)[:studies][:research_involving][:products][:ind_on_hold], class: 'col-lg-2 control-label'
@@ -132,10 +138,11 @@
             .form-group.row.inv-device{ class: ("hidden" unless exemption_type.present?) }
               = ip_form.label "exemption_type_#{exemption_type}", t(:protocols)[:studies][:research_involving][:products][:numbers][exemption_type.to_sym], class: 'col-lg-2 control-label'
               .col-lg-1.text-center
-                = ip_form.radio_button :exemption_type, exemption_type, class: 'form-control exemption-radio'
+                = ip_form.radio_button :exemption_type, exemption_type, class: 'form-control exemption-radio', data: { type: exemption_type }
               - if exemption_type == ip_form.object.exemption_type
                 .col-lg-9.inv-device-number-field
-                  = ip_form.text_field :inv_device_number, class: 'form-control'
+                  = link_to 'javascript:void(0)', class: 'device-number', data: { toggle: 'tooltip', placement: 'bottom' } do
+                    = ip_form.text_field :inv_device_number, class: 'form-control'
           .form-group.row
             .col-sm-2
               %button.btn.btn-danger.clear-inv-device-number-button.pull-right

--- a/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
@@ -36,27 +36,38 @@
     .form-group.row
       = form.label :short_title, t(:protocols)[:studies][:information][:short_title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :short_title, class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')], disabled: @protocol.research_master_id
+        = form.text_field :short_title,
+          class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
+          disabled: @protocol.research_master_id,
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:short_title]
 
     .form-group.row
       = form.label :title, t(:protocols)[:studies][:information][:title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :title, class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')], disabled: @protocol.research_master_id
+        = form.text_field :title,
+          class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
+          disabled: @protocol.research_master_id,
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:title]
 
     .form-group.row#funding-status
       = form.label :funding_status, t(:protocols)[:studies][:information][:funding_status], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker study'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_status] do
+          = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker study'
 
     .form-group.row.funding_status_dependent.funded{ display_if(protocol.funding_status, "funded") }
       = form.label :funding_source, t(:protocols)[:studies][:information][:funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', class: 'funding-source-tooltip', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_source] do
+          = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :potential_funding_source, t(:protocols)[:studies][:information][:potential_funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', class: 'funding-source-tooltip', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:potential_funding_source] do
+          = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
 
     / Internal Funded Pilot Project selected
     .form-group.row.funding_status_dependent.funding_source_dependent.internal{ display_if(protocol.funding_source, "internal") }
@@ -100,7 +111,9 @@
     .form-group.row
       = form.label :sponsor_name, t(:protocols)[:studies][:information][:sponsor], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :sponsor_name, class: 'form-control'
+        = form.text_field :sponsor_name, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:sponsor_name]
 
     / Display epic questions as readonly for administrators who aren't an authorized user
     / with edit abilities

--- a/app/views/protocols/form/_project_fields.html.haml
+++ b/app/views/protocols/form/_project_fields.html.haml
@@ -25,27 +25,34 @@
     .form-group.row
       = form.label :short_title, t(:protocols)[:projects][:information][:short_title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :short_title, class: 'form-control'
+        = form.text_field :short_title, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:short_title]
 
     .form-group.row
       = form.label :title, t(:protocols)[:projects][:information][:title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :title, class: 'form-control'
+        = form.text_field :title, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:title]
 
     .form-group.row#funding-status
       = form.label :funding_status, t(:protocols)[:projects][:information][:funding_status], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker project'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_status] do
+          = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker project'
   
     .form-group.row.funding_status_dependent.funded{ display_if(protocol.funding_status, "funded") }
       = form.label :funding_source, t(:protocols)[:projects][:information][:funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_source] do
+          = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :potential_funding_source, t(:protocols)[:projects][:information][:potential_funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:potential_funding_source] do
+          = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
 
     .form-group.row
       = form.label :brief_description, t(:protocols)[:projects][:information][:description], class: "col-lg-2 control-label"

--- a/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -22,15 +22,22 @@
 .form-group.row
   = form.label :selected_for_epic, t(:protocols)[:studies][:information][:push_to_epic], class: 'col-lg-2 control-label required'
   .col-lg-10
-    .btn-group#selected_for_epic_button{data: {toggle: "labels"}}
-      %label.radio-inline.btn.btn-default#study_selected_for_epic_true_button{ class: protocol.selected_for_epic? ? 'active' : ''}
-        = form.radio_button :selected_for_epic, 'true', id: "study_selected_for_epic_true", class: 'hidden'
-        = t(:constants)[:yes_select]
-      %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false ? 'active' : ''}
-        = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
-        = t(:constants)[:no_select]
+    = link_to 'javascript:void(0)',
+      data: { toggle: 'tooltip', placement: 'right' },
+      title: t(:protocols)[:tooltips][:epic] do
+      .btn-group#selected_for_epic_button{data: { toggle: "labels" } }
+        %label.radio-inline.btn.btn-default#study_selected_for_epic_true_button{ class: protocol.selected_for_epic? ? 'active' : ''}
+          = form.radio_button :selected_for_epic, 'true', id: "study_selected_for_epic_true", class: 'hidden'
+          = t(:constants)[:yes_select]
+        %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false ? 'active' : ''}
+          = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
+          = t(:constants)[:no_select]
 .form-group.row.selected_for_epic_dependent{ display_if(protocol.selected_for_epic) }
-  = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: 'col-lg-2 control-label required'
+  = form.label :study_type_questions,
+    t(:protocols)[:studies][:information][:study_type_questions],
+    class: 'col-lg-2 control-label required',
+    data: { toggle: 'tooltip', placement: 'right' },
+    title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10
     - action_name == 'update_protocol_type' ? protocol.setup_study_type_answers : ''
     = form.fields_for :study_type_answers, protocol.study_type_answers do |answer_form|

--- a/app/views/protocols/form/study_form_sections/_research_involving.html.haml
+++ b/app/views/protocols/form/study_form_sections/_research_involving.html.haml
@@ -37,7 +37,9 @@
           .form-group.row.nct-number
             = hs_form.label :nct_number, t(:protocols)[:studies][:research_involving][:humans][:nct_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :nct_number, class: 'form-control'
+              = hs_form.text_field :nct_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: t(:protocols)[:tooltips][:nct_number]
 
           .form-group.row
             = hs_form.label :hr_number, t(:protocols)[:studies][:research_involving][:humans][:hr_number], class: 'col-lg-2 control-label'
@@ -47,7 +49,9 @@
           .form-group.row
             = hs_form.label :pro_number, t(:protocols)[:studies][:research_involving][:humans][:pro_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :pro_number, class: 'form-control'
+              = hs_form.text_field :pro_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: t(:protocols)[:tooltips][:pro_number]
 
           .form-group.row
             = hs_form.label :irb_of_record, t(:protocols)[:studies][:research_involving][:humans][:record_irb], class: 'col-lg-2 control-label'
@@ -120,10 +124,13 @@
           .form-group.row
             = ip_form.label :ind_number, t(:protocols)[:studies][:research_involving][:products][:ind_number], class: 'col-lg-2 control-label'
             .col-lg-10
-              = ip_form.text_field :ind_number, class: 'form-control'
+              = ip_form.text_field :ind_number, class: 'form-control',
+                data: { toggle: 'tooltip', placement: 'bottom' },
+                title: 'Investigational New Drug (IND) Number'
 
           .form-group.row#ind-on-hold-group{ display_if(!ip_form.object.ind_number.blank?) }
-            = ip_form.label :ind_on_hold, t(:protocols)[:studies][:research_involving][:products][:ind_on_hold], class: 'col-lg-2 control-label'
+            = ip_form.label :ind_on_hold,
+              t(:protocols)[:studies][:research_involving][:products][:ind_on_hold], class: 'col-lg-2 control-label'
             .col-lg-1
               = ip_form.check_box :ind_on_hold, class: 'form-control'
 
@@ -132,10 +139,11 @@
             .form-group.row.inv-device{ class: ("hidden" unless exemption_type.present?) }
               = ip_form.label "exemption_type_#{exemption_type}", t(:protocols)[:studies][:research_involving][:products][:numbers][exemption_type.to_sym], class: 'col-lg-2 control-label'
               .col-lg-1.text-center
-                = ip_form.radio_button :exemption_type, exemption_type, class: 'form-control exemption-radio'
+                = ip_form.radio_button :exemption_type, exemption_type, class: "form-control exemption-radio", data: { type: exemption_type }
               - if exemption_type == ip_form.object.exemption_type
                 .col-lg-9.inv-device-number-field
-                  = ip_form.text_field :inv_device_number, class: 'form-control'
+                  = link_to 'javascript:void(0)', class: 'device-number', data: { toggle: 'tooltip', placement: 'bottom' } do
+                    = ip_form.text_field :inv_device_number, class: "form-control"
           .form-group.row
             .col-sm-2
               %button.btn.btn-danger.clear-inv-device-number-button.pull-right

--- a/app/views/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/protocols/form/study_form_sections/_study_information.html.haml
@@ -36,27 +36,38 @@
     .form-group.row
       = form.label :short_title, t(:protocols)[:studies][:information][:short_title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :short_title, class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')], disabled: @protocol.research_master_id
+        = form.text_field :short_title,
+          class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
+          disabled: @protocol.research_master_id,
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:short_title]
 
     .form-group.row
       = form.label :title, t(:protocols)[:studies][:information][:title], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :title, class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')], disabled: @protocol.research_master_id
+        = form.text_field :title,
+          class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
+          disabled: @protocol.research_master_id,
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:title]
 
     .form-group.row#funding-status
       = form.label :funding_status, t(:protocols)[:studies][:information][:funding_status], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker study'
+        = link_to 'javascript:void(0)', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_status] do
+          = form.select :funding_status, options_for_select(FUNDING_STATUSES, protocol.funding_status), { include_blank: t(:protocols)[:prompts][:status] }, class: 'selectpicker study'
 
     .form-group.row.funding_status_dependent.funded{ display_if(protocol.funding_status, "funded") }
       = form.label :funding_source, t(:protocols)[:studies][:information][:funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', class: 'funding-source-tooltip', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:funding_source] do
+          = form.select :funding_source, options_for_select(FUNDING_SOURCES, protocol.funding_source), { include_blank: t(:protocols)[:prompts][:source] }, class: 'selectpicker'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :potential_funding_source, t(:protocols)[:studies][:information][:potential_funding_source], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
+        = link_to 'javascript:void(0)', class: 'funding-source-tooltip', data: { toggle: 'tooltip', placement: 'right' }, title: t(:protocols)[:tooltips][:potential_funding_source] do
+          = form.select :potential_funding_source, options_for_select(POTENTIAL_FUNDING_SOURCES, protocol.potential_funding_source), { include_blank: t(:protocols)[:prompts][:potential_source] }, class: 'selectpicker'
 
     / Internal Funded Pilot Project selected
     .form-group.row.funding_status_dependent.funding_source_dependent.internal{ display_if(protocol.funding_source, "internal") }
@@ -100,7 +111,9 @@
     .form-group.row
       = form.label :sponsor_name, t(:protocols)[:studies][:information][:sponsor], class: 'col-lg-2 control-label required'
       .col-lg-10
-        = form.text_field :sponsor_name, class: 'form-control'
+        = form.text_field :sponsor_name, class: 'form-control',
+          data: { toggle: 'tooltip', placement: 'bottom' },
+          title: t(:protocols)[:tooltips][:sponsor_name]
     - if USE_EPIC
       = render partial: 'protocols/form/study_form_sections/interactive_form', locals: { protocol: protocol, form: form }
       = render partial: 'protocols/form/study_form_sections/study_type_note', locals: { protocol: protocol, form: form }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,6 +415,18 @@ en:
       federal_sponsor: "Select if Applicable"
       phase: "Select a Study Phase"
       submission_type: "Select a Submission Type"
+    tooltips:
+      epic: 'Defines whether record will interface to Epic EMR upon submission'
+      study_type_questions: 'Information needed to determine confidentiality of patients/protocols in Epic'
+      nct_number: 'Clinicaltrials.gov Registry Number'
+      pro_number: 'Institutional Review Board (IRB) Unique Identifier'
+      ind_number: 'Investigational New Drug (IND) Number'
+      short_title: 'An abbreviated form of the title used to identify your study/project'
+      title: 'Full title of your study/project'
+      funding_status: 'Indicates whether or not funding has been applied for or obtained'
+      potential_funding_source: 'Funding source that has been applied for but not yet obtained. Pricing is logically driven off this field'
+      funding_source: 'Funding source which drives research pricing for your study/project'
+      sponsor_name: 'Specify name of the entity funding the project/study'
     authorized_users:
       header: "Add Primary PI"
       primary_pi: "Primary PI: *"


### PR DESCRIPTION
Added tooltips to the SPARCRequest Step 1 Protocol
Information Page and Dashboard edit page. Some of the bootstrap selects
were acting weird with normal markup so I wrapped them in anchor tags,
seems to work fine. Open to suggestions on the JS code in this
PR, does the job but maybe there is a better way if anyone has ideas. [#140086745]