### PR TITLE
wth - (SPARCReport) Service Request Report Adding Coumn

### DIFF
--- a/app/reports/service_requests.rb
+++ b/app/reports/service_requests.rb
@@ -38,7 +38,7 @@ class ServiceRequestsReport < ReportingModule
       "Tags" => {:field_type => :text_field_tag},
       "Current Status" => {:field_type => :check_box_tag, :for => 'status', :multiple => AVAILABLE_STATUSES},
       "Show APR Data" => {:field_type => :check_box_tag, :for => 'apr_data', :multiple => {"irb" => "IRB", "iacuc" => "IACUC"}},
-      "Show SPARCFulfillment Information" => {:field_type => :check_box_tag, :for => 'fulfillment_info' }
+      "Show SPARCFulfillment Information" => {:field_type => :check_box_tag, :for => 'fulfillment_info', :field_label => 'Show SPARCFulfillment Information' }
     }
   end
 

--- a/app/views/reports/_setup.html.haml
+++ b/app/views/reports/_setup.html.haml
@@ -151,7 +151,7 @@
           - else # for individual checkboxes that have true/false
             / %label{:for => options[:for]}= field_label
             .col-sm-9
-              = check_box_tag name, true, nil, :class => default_classes + " form-control", :type => "checkbox"
+              = check_box_tag name, true, nil, :class => default_classes, :type => "checkbox"
             /* TODO define behavior if multiple is a method or string representation of method chain */
 
         /* end check_box_tag */


### PR DESCRIPTION
1). Added a "Show SPARCFulfillment Information" checkbox on the filter
page. Had to change default_classes variable to ternary because this will not be a required field.

2). When the user checks the "Show SPARCFulfillment Information"
checkbox, a "Sent to SPARCFulfillment" column is added to the generated
report showing whether the corresponding SSR has been pushed to
Fulfillment.

[#139974195]

minor style revisions