### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Tooltips: Step 1 Authorized Users

### DIFF
--- a/app/helpers/associated_users_helper.rb
+++ b/app/helpers/associated_users_helper.rb
@@ -24,12 +24,17 @@ module AssociatedUsersHelper
   #        Also used in form helpers.
   # classes - HTML classes to add to form-group.
   # label - Override localized label text.
-  def user_form_group(form: nil, name:, classes: [], label: nil)
+  def user_form_group(form: nil, name:, classes: [], label: nil, data: {}, title: nil)
     form_group_classes = %w(row form-group) + [classes]
     label_class = 'col-lg-3 control-label'
     label_text = label || t(:authorized_users)[:form_fields][name.to_sym]
     label = if form
-              form.label(name, label_text, class: label_class)
+              form.label(name,
+                         label_text,
+                         class: label_class,
+                         data: data,
+                         title: title
+                        )
             else
               content_tag(:label, label_text, class: label_class)
             end

--- a/app/views/associated_users/_user_form.html.haml
+++ b/app/views/associated_users/_user_form.html.haml
@@ -63,17 +63,16 @@
               = form.text_field :role_other, class: 'form-control'
 
             - if USE_EPIC && protocol != nil && protocol.selected_for_epic
-              = user_form_group(name: :epic_access, form: form) do
-                .col-lg-9
-                  %label.checkbox-inline
-                    No
+              = user_form_group(name: :epic_access, form: form, data: { toggle: 'tooltip', placement: 'right' }, title: t(:authorized_users)[:tooltips][:epic_access]) do
+                = label_tag nil, nil, class: 'radio-inline' do
                   = form.radio_button :epic_access, false, class: 'epic_access'
-                  %label.checkbox-inline
-                    Yes
+                  No
+                = label_tag nil, nil, class: 'radio-inline' do
                   = form.radio_button :epic_access, true, class: 'epic_access'
+                  Yes
 
             - disable = (form.object.role == 'pi' || form.object.role == 'primary-pi')
-            = user_form_group(name: :rights, form: form) do
+            = user_form_group(name: :rights, form: form, data: { toggle: 'tooltip', placement: 'bottom' }, title: t(:authorized_users)[:tooltips][:rights]) do
               .radio
                 %label
                   = form.radio_button :project_rights, "none", disabled: disable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,9 @@ en:
       phone: "Phone"
       rights: "Proxy Rights"
       epic_emr_access: 'EPIC EMR Access'
+    tooltips:
+      epic_access: 'Granting Epic EMR access populates study personnel in Epic Research Record as long as they have an Epic login'
+      rights: 'Defines access to protocol in SPARCDashboard'
 
   #############
   # CALENDARS #

--- a/spec/views/proper/associated_users/_user_form.html.haml_spec.rb
+++ b/spec/views/proper/associated_users/_user_form.html.haml_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe '/associated_users/_user_form', type: :view do
     it 'should show the correct form fields when not using epic and protocol is not selected for epic' do
       render_user_form
       expect(response).to have_selector('.radio', 4)
-      expect(response).to have_selector('.checkbox-inline', count: 0)
+      expect(response).to have_selector('.radio-inline', count: 0)
       expect(response).not_to have_selector('label', text: 'No')
       expect(response).not_to have_selector('label', text: 'Yes')
     end
@@ -50,7 +50,7 @@ RSpec.describe '/associated_users/_user_form', type: :view do
       render_user_form true
       expect(response).to have_selector('label', text: 'No')
       expect(response).to have_selector('label', text: 'Yes')
-      expect(response).to have_selector('.checkbox-inline', count: 2)
+      expect(response).to have_selector('.radio-inline', count: 2)
     end
   end
 end


### PR DESCRIPTION
Added keyword arguments to user_form helper in order to add tooltips to
labels. Refactored how inline radio labels are displayed in form, since
the markup was all wrong per Bootstrap docs (http://getbootstrap.com/css/#inline-checkboxes-and-radios). This fixed an issue where the radio buttons didn't align with the other inputs in the form.
[#140087627]