### PR TITLE
Sj empty protocol admin view

### DIFF
--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -75,7 +75,7 @@ class Dashboard::BaseController < ActionController::Base
   end
 
   def find_admin_for_protocol
-    if @user.super_users.any? && @protocol.service_requests.empty?
+    if @user.super_users.any? && @protocol.sub_service_requests.empty?
       @admin = true
     else
       @admin = Protocol.for_admin(@user).include?(@protocol)

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -75,6 +75,10 @@ class Dashboard::BaseController < ActionController::Base
   end
 
   def find_admin_for_protocol
-    @admin = Protocol.for_admin(@user).include?(@protocol)
+    if @user.super_users.any? && @protocol.service_requests.empty?
+      @admin = true
+    else
+      @admin = Protocol.for_admin(@user).include?(@protocol)
+    end
   end
 end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -250,8 +250,8 @@ class Protocol < ActiveRecord::Base
 
     ssrs = SubServiceRequest.where.not(status: 'first_draft').where(organization_id: Organization.authorized_for_identity(identity_id))
 
-    joins(:sub_service_requests).
-      merge(ssrs).distinct
+    with_requests = joins(:sub_service_requests).merge(ssrs).distinct
+    Identity.find(identity_id).super_users.any? ? with_requests + includes(:service_requests).where(service_requests: {id: nil}) : with_requests
   }
 
   scope :show_archived, -> (boolean) {

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -200,7 +200,7 @@ class Protocol < ActiveRecord::Base
 
     #TODO temporary replacement for "MATCH(identities.first_name, identities.last_name) AGAINST (#{exact_search_term})"
     case search_attrs[:search_drop]
-      
+
     when "PI"
       joins(:principal_investigators).
         where("CONCAT(identities.first_name, ' ', identities.last_name) LIKE #{like_search_term} escape '!'").
@@ -228,30 +228,38 @@ class Protocol < ActiveRecord::Base
 
   }
 
-  scope :for_identity_id, -> (identity_id) {
-    return nil if identity_id == '0'
-    joins(:project_roles).
-      where(project_roles: { identity_id: identity_id }).
-      where.not(project_roles: { project_rights: 'none' })
-  }
-
   scope :admin_filter, -> (params) {
     filter, id  = params.split(" ")
     if filter == 'for_admin'
       for_admin(id)
     elsif filter == 'for_identity'
       for_identity_id(id)
+    elsif filter == 'empty_protocols'
+      empty_protocols(id)
     end
   }
 
   scope :for_admin, -> (identity_id) {
     # returns protocols with ssrs in orgs authorized for identity_id
     return nil if identity_id == '0'
-
     ssrs = SubServiceRequest.where.not(status: 'first_draft').where(organization_id: Organization.authorized_for_identity(identity_id))
+    joins(:sub_service_requests).merge(ssrs).distinct
+  }
 
-    with_requests = joins(:sub_service_requests).merge(ssrs).distinct
-    Identity.find(identity_id).super_users.any? ? with_requests + includes(:service_requests).where(service_requests: {id: nil}) : with_requests
+  scope :for_identity_id, -> (identity_id) {
+    # returns protocols user has a project role for
+    return nil if identity_id == '0'
+    joins(:project_roles).where(project_roles: { identity_id: identity_id }).where.not(project_roles: { project_rights: 'none' })
+  }
+
+  scope :empty_protocols, -> (identity_id) {
+    # returns protocols with no ssrs if you are a super user of any kind
+    return nil if identity_id == '0'
+    if Identity.find(identity_id).super_users.any?
+      includes(:sub_service_requests).where(sub_service_requests: {id: nil})
+    else
+      return nil
+    end
   }
 
   scope :show_archived, -> (boolean) {
@@ -288,7 +296,7 @@ class Protocol < ActiveRecord::Base
     sort_order  = arr[1]
     case sort_name
     when 'id'
-      order("id #{sort_order.upcase}")
+      order("protocols.id #{sort_order.upcase}")
     when 'short_title'
       order("TRIM(REPLACE(short_title, CHAR(9), ' ')) #{sort_order.upcase}")
     when 'pis'

--- a/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
+++ b/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
@@ -39,7 +39,7 @@
               = form.fields_for :search_query do |search|
                 .input-group-btn
                   .dd_select
-                    = search.select :search_drop, t(:dashboard)[:protocol_filters][:search_by_options], { prompt:  t(:dashboard)[:protocol_filters][:search_by] }, class: "form-control selectpicker ", data: { style: 'dropdown_filter' }  
+                    = search.select :search_drop, t(:dashboard)[:protocol_filters][:search_by_options], { prompt:  t(:dashboard)[:protocol_filters][:search_by] }, class: "form-control selectpicker ", data: { style: 'dropdown_filter' }
                 = search.text_field :search_text, class: 'form-control', disabled: true
 
         .form-group.row
@@ -75,6 +75,12 @@
             = form.label :admin_filter, t(:dashboard)[:protocol_filters][:my_admin_protocols], class: 'col-lg-10 control-label'
             .col-lg-2
               = form.radio_button :admin_filter, "for_admin #{current_user.id}"
+
+          - if current_user.super_users.any?
+            .form-group.row.empty-protocols
+              = form.label :admin_filter, t(:dashboard)[:protocol_filters][:empty_protocols], class: 'col-lg-10 control-label'
+              .col-lg-2
+                = form.radio_button :admin_filter, "empty_protocols #{current_user.id}"
 
     .panel-footer
       .pull-right

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -166,6 +166,7 @@ en:
       owner: "Owner"
       my_protocols: "My Protocols"
       my_admin_protocols: "My Admin Protocols"
+      empty_protocols: "Empty Protocols (No Services)"
       filter: "Filter"
       saved_filters:
         header: "Recently Saved Filters"

--- a/spec/support/pages/dashboard/protocols/index_page.rb
+++ b/spec/support/pages/dashboard/protocols/index_page.rb
@@ -38,12 +38,13 @@ module Dashboard
         elements :status_options, "div.status-select li"
         element :core_select, "div.core-select button"
         elements :core_options, "div.core-select li"
-        
+
         # these appear if user is an admin
         element :owner_select, "div.owner-select button"
         elements :owner_options, "div.owner-select li"
         element :my_protocols_checkbox, ".identity-protocols input"
         element :my_admin_organizations_checkbox, ".admin-protocols input"
+        element :empty_protocols_checkbox, ".empty-protocols input"
 
         element :apply_filter_button, :button, "Filter"
 


### PR DESCRIPTION
Allowing super users (any super users) to view any protocol without SUB service requests. This covers both the authorization to view them, and adding an "empty protocols" option to dashboard if  you are a super user. [#140144393]