### PR TITLE
SAW - Edit protocol RMID changes

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -68,6 +68,9 @@ $(document).ready ->
       resetRmIdFields('.rm-id-dependent', '')
       toggleFields('.rm-locked-fields', false)
 
+  $(document).on 'click', '.edit-rmid', ->
+    $('#protocol_research_master_id').prop('readonly', false)
+
   $('#protocol-form-display form').bind 'submit', ->
     $(this).find(':input').prop('disabled', false)
 

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -264,7 +264,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     attrs
   end
 
-  def save_protocol_with_blank_rmid_if_admin attrs
+  def save_protocol_with_blank_rmid_if_admin(attrs)
     @protocol.assign_attributes(attrs)
     if @admin && !@protocol.valid? && @protocol.errors.full_messages == ["Research master can't be blank"]
       @protocol.save(validate: false)

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -139,6 +139,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
 
     @protocol.valid?
     @errors = @protocol.errors
+    @errors.delete(:research_master_id) if @admin
 
     respond_to do |format|
       format.html
@@ -269,6 +270,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     if @admin && !@protocol.valid? && @protocol.errors.full_messages == ["Research master can't be blank"]
       @protocol.save(validate: false)
     else
+      @protocol.errors.delete(:research_master_id) if @admin
       @protocol.save
     end
   end

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -157,7 +157,8 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     attrs               = fix_date_params
     permission_to_edit  = @authorization.present? ? @authorization.can_edit? : false
     # admin is not able to activate study_type_question_group
-    if @protocol.update_attributes(attrs)
+
+    if save_protocol_with_blank_rmid_if_admin(attrs)
       flash[:success] = I18n.t('protocols.updated', protocol_type: @protocol.type)
     else
       @errors = @protocol.errors
@@ -261,5 +262,14 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     end
 
     attrs
+  end
+
+  def save_protocol_with_blank_rmid_if_admin attrs
+    @protocol.assign_attributes(attrs)
+    if @admin && !@protocol.valid? && @protocol.errors.full_messages == ["Research master can't be blank"]
+      @protocol.save(validate: false)
+    else
+      @protocol.save
+    end
   end
 end

--- a/app/views/dashboard/protocols/edit.html.haml
+++ b/app/views/dashboard/protocols/edit.html.haml
@@ -24,4 +24,4 @@
     = render 'shared/modal_errors', errors: @errors
 #protocol
   = render 'dashboard/protocols/form/edit_protocol_type', protocol: @protocol, protocol_type: @protocol_type, in_dashboard: @in_dashboard
-  = render 'dashboard/protocols/form/protocol_form', protocol: @protocol, protocol_type: @protocol_type, admin: @admin, permission_to_edit: @permission_to_edit
+  = render 'dashboard/protocols/form/protocol_form', protocol: @protocol, protocol_type: @protocol_type, admin: @admin, permission_to_edit: @permission_to_edit, action_name: action_name

--- a/app/views/dashboard/protocols/form/_protocol_form.html.haml
+++ b/app/views/dashboard/protocols/form/_protocol_form.html.haml
@@ -26,7 +26,7 @@
     - if @protocol.type.capitalize == "Study"
       .edit-study-view.container-fluid
         .row.user-edit-protocol-view
-          = render partial: 'dashboard/protocols/form/study_fields', locals: { form: form, protocol: protocol, admin: admin, permission_to_edit: permission_to_edit }
+          = render partial: 'dashboard/protocols/form/study_fields', locals: { form: form, protocol: protocol, admin: admin, permission_to_edit: permission_to_edit, action_name: action_name }
 
     - elsif @protocol.type.capitalize == "Project"
       .edit-project-view.container-fluid

--- a/app/views/dashboard/protocols/form/_study_fields.html.haml
+++ b/app/views/dashboard/protocols/form/_study_fields.html.haml
@@ -17,7 +17,7 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-= render 'dashboard/protocols/form/study_form_sections/study_information', protocol: protocol, form: form, admin: admin, permission_to_edit: permission_to_edit
+= render 'dashboard/protocols/form/study_form_sections/study_information', protocol: protocol, form: form, admin: admin, permission_to_edit: permission_to_edit, action_name: action_name
 = render 'dashboard/protocols/form/study_form_sections/optional_information', protocol: protocol, form: form
 = render 'dashboard/protocols/form/study_form_sections/research_involving', protocol: protocol, form: form
 = render 'dashboard/protocols/form/study_form_sections/study_type', protocol: protocol, form: form

--- a/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
@@ -29,9 +29,12 @@
       .form-group.row
         = form.label :research_master_id, class: 'col-lg-2 control-label rm-id' do
           = link_to t(:protocols)[:studies][:information][:research_master_id], RESEARCH_MASTER_LINK
-        .col-lg-10
-          = form.text_field :research_master_id, class: 'form-control research-master-field'
+        .col-lg-3
+          = form.text_field :research_master_id, class: 'form-control research-master-field', readonly: action_name == "edit" && admin
           = form.hidden_field :has_human_subject_info, value: false, class: 'has-human-subject-info'
+        - if action_name == "edit" && admin
+          .btn.btn-warning.edit-rmid
+            = t(:actions)[:edit]
 
     .form-group.row
       = form.label :short_title, t(:protocols)[:studies][:information][:short_title], class: 'col-lg-2 control-label required'

--- a/spec/controllers/dashboard/protocols/put_update_spec.rb
+++ b/spec/controllers/dashboard/protocols/put_update_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe Dashboard::ProtocolsController do
         before(:each) do
           @logged_in_user = build_stubbed(:identity)
           log_in_dashboard_identity(obj: @logged_in_user)
-          @protocol = findable_stub(Protocol) do
-            build_stubbed(:protocol, type: "Project")
-          end
+          @protocol = create(:protocol_federally_funded, primary_pi: @logged_in_user)
           authorize(@logged_in_user, @protocol, can_edit: false)
 
           xhr :get, :update, id: @protocol.id
@@ -45,24 +43,19 @@ RSpec.describe Dashboard::ProtocolsController do
             @logged_in_user = build_stubbed(:identity)
             log_in_dashboard_identity(obj: @logged_in_user)
 
-            @protocol = findable_stub(Protocol) do
-              build_stubbed(:protocol, type: "Project")
-            end
+            @protocol = create(:protocol_federally_funded, primary_pi: @logged_in_user)
             authorize(@logged_in_user, @protocol, can_edit: true)
 
             # let us have an active StudyTypeQuestionGroup
             allow(StudyTypeQuestionGroup).to receive(:active_id).
               and_return("active group id")
 
-            allow(@protocol).to receive(:update_attributes).
-              and_return(true)
-
-            xhr :get, :update, id: @protocol.id, protocol: { some_attribute: "some value" }
+            xhr :get, :update, id: @protocol.id, protocol: { title: "New Title" }
           end
 
           it "should update Protocol <- params[:id] as specified in params[:protocol] and update its StudyTypeQuestionGroup to the active one" do
-            expect(@protocol).to have_received(:update_attributes).
-              with(some_attribute: "some value")
+            @protocol.reload
+            expect(@protocol.title).to eq("New Title")
           end
 
           it "should not set @errors" do
@@ -78,24 +71,22 @@ RSpec.describe Dashboard::ProtocolsController do
             @logged_in_user = build_stubbed(:identity)
             log_in_dashboard_identity(obj: @logged_in_user)
 
-            @protocol = findable_stub(Protocol) do
-              build_stubbed(:protocol, type: "Project")
-            end
-            allow(@protocol).to receive(:errors).and_return("oh god")
+            @protocol = create(:protocol_without_validations,
+                primary_pi: @logged_in_user,
+                funding_status: "funded",
+                funding_source: "skrill",
+                title: "")
             authorize(@logged_in_user, @protocol, can_edit: true)
 
             # let us have an active StudyTypeQuestionGroup
             allow(StudyTypeQuestionGroup).to receive(:active_id).
               and_return("active group id")
 
-            allow(@protocol).to receive(:update_attributes).
-              and_return(false)
-
             xhr :get, :update, id: @protocol.id, protocol: { some_attribute: "some value" }
           end
 
           it 'should set @errors to Protocol\'s errors attribute' do
-            expect(assigns(:errors)).to eq('oh god')
+            expect(assigns(:errors).full_messages).to eq(["Title can't be blank"])
           end
         end
       end

--- a/spec/features/dashboard/protocols/edit/user_edits_research_master_on_study.rb
+++ b/spec/features/dashboard/protocols/edit/user_edits_research_master_on_study.rb
@@ -1,0 +1,73 @@
+# Copyright © 2011 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rails_helper'
+
+RSpec.describe 'User edits research master id on study', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
+  build_study_phases
+
+  context 'User is an admin' do
+    before :each do
+      @protocol       = create(:protocol_without_validations,
+                                type: "Study",
+                                primary_pi: jug2,
+                                funding_status: "funded",
+                                funding_source: "foundation",
+                                has_human_subject_info: true)
+      organization    = create(:organization)
+      service_request = create(:service_request_without_validations, protocol: @protocol)
+                        create(:sub_service_request_without_validations, organization: organization, service_request: service_request, status: 'draft')
+                        create(:super_user, identity: jug2, organization: organization)
+      stub_const("RESEARCH_MASTER_ENABLED", true)
+
+      visit edit_dashboard_protocol_path(@protocol)
+      wait_for_javascript_to_finish
+    end
+
+    it 'and sees readonly Research Master field' do
+      expect(page).to have_selector('.research-master-field[readonly="readonly"]')
+    end
+
+    it 'and clicks edit button to edit Research Master field' do
+      find('.edit-rmid').click
+      expect(page).to have_selector('.research-master-field:not([readonly="readonly"])')
+    end
+  end
+
+  context 'User is not an admin' do
+    it 'and sees editable field' do
+      @protocol       = create(:protocol_without_validations,
+                                type: "Study",
+                                primary_pi: jug2,
+                                funding_status: "funded",
+                                funding_source: "foundation",
+                                has_human_subject_info: true)
+      stub_const("RESEARCH_MASTER_ENABLED", true)
+
+      visit edit_dashboard_protocol_path(@protocol)
+      wait_for_javascript_to_finish
+
+      expect(page).to have_selector('.research-master-field:not([readonly="readonly"])')
+    end
+  end
+
+end


### PR DESCRIPTION
If the user is an admin and edits a study on the dashboard, then the Research Master ID field is read only, unless they click the edit button to the right of the field. Clicking this button makes the field editable.
Also, if the user is a admin, then the Research Master ID is allowed to be saved blank. This skips the validation to ensure that RMID is present.
If the user is not an admin, then the Research Master ID field is always editable and no validations are skipped.