### PR TITLE
wth - SPARCCatalog Pricing Map Rates (Section): Delete Override Price

### DIFF
--- a/app/assets/javascripts/catalog_manager/update.js.coffee
+++ b/app/assets/javascripts/catalog_manager/update.js.coffee
@@ -74,6 +74,11 @@ $(document).ready ->
     validate_numbers_only(this)
   )
 
+  $(document).on 'change', '.rate_field', ->
+    if $(this).val() == ''
+      service_rate = $(this).closest('fieldset').find('.service_rate').val()
+      $(this).val(service_rate)
+
   $('.apply_federal_to_all_link').live('click', ->
     federal_value = $(this).closest('tr').siblings('.federal_row').find('.federal_percentage_field').val()
     $(this).closest('tr').siblings('.corporate_row').find('.corporate_percentage_field').val(federal_value).change()


### PR DESCRIPTION
Revamp

In SPARCCatalog, when inside the pricing map section of a service and
trying to delete an existing override price, and click "Save", there was
no error message, however, the change was not saved because it was a NaN
(Not a Number).

I added jQuery code to check if the input is blank and if so, replace it
with the calculated rate. [#127112423]