### PR TITLE
wth - (SPARCDashboard) Search All is not Including Projects

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -230,8 +230,8 @@ class Protocol < ActiveRecord::Base
     when "Short/Long Title"
       where(title_query.join(' OR ')).distinct
     when ""
-      all_query = [authorized_user_query, hr_query, pi_query, protocol_id_query, pro_num_query, rmid_query, title_query]
-      joins(:identities).joins(:human_subjects_info).
+      all_query = [authorized_user_query, pi_query, protocol_id_query, title_query]
+      joins(:identities).
         where(all_query.compact.join(' OR ')).
         distinct
     end


### PR DESCRIPTION
It was failing to include Projects because it was trying to search for
attributes that do not belong to Projects (pro_number, hr#, rmid).
Revised the search all function to only search for shared attributes
between Projects & Studies. [#141901591]