### PR TITLE
wth - (SPARCDashboard) Saved Filters Bug

### DIFF
--- a/app/models/protocol_filter.rb
+++ b/app/models/protocol_filter.rb
@@ -48,7 +48,7 @@ class ProtocolFilter < ActiveRecord::Base
       filterrific: {
         show_archived: (self.show_archived ? 1 : 0),
         admin_filter: self.admin_filter,
-        search_query: self.search_query,
+        search_query: eval(self.search_query),
         with_organization: self.with_organization,
         with_status: self.with_status,
         with_owner: self.with_owner,

--- a/lib/tasks/update_protocol_filters.rake
+++ b/lib/tasks/update_protocol_filters.rake
@@ -1,0 +1,15 @@
+namespace :data do
+  task update_protocol_filters: :environment do
+    protocol_filters = ProtocolFilter.all
+
+    protocol_filters.each do |pf|
+      if pf.search_query.blank?
+        pf.update_attribute(:search_query, '{"search_drop"=>"", "search_text"=>""}')
+      elsif pf.search_query.include? '{'
+      else
+        query = pf.search_query
+        pf.update_attribute(:search_query, "{'search_drop'=>'', 'search_text'=>'#{query}'}")
+      end
+    end
+  end
+end

--- a/spec/features/dashboard/protocols/index/filters_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters_spec.rb
@@ -982,6 +982,56 @@ RSpec.describe "filters", js: :true do
     end
   end
 
+  describe 'saved searches' do
+    before :each do
+      organization1 = create(:organization)
+      organization2 = create(:organization)
+      organization3 = create(:organization)
+      create(:service_provider, organization: organization1, identity: user)
+      create(:service_provider, organization: organization2, identity: user)
+      create(:service_provider, organization: organization3, identity: user)
+
+      @protocol1 = create_protocol(id: 888888, archived: false, title: "titlex", short_title: "Protocol1")
+      create(:project_role, identity: user, role: "very-important", project_rights: "to-party", protocol: @protocol1)
+
+      @protocol2 = create_protocol(id: 777777, archived: false, title: "xTitle", short_title: "Protocol2")
+      create(:project_role, identity: user, role: "very-important", project_rights: "to-party", protocol: @protocol2)
+
+      @protocol3 = create_protocol(archived: false, title: "888888", short_title: "Protocol3", research_master_id: 999999)
+      create(:project_role, identity: user2, role: "very-important", project_rights: "to-party", protocol: @protocol3)
+
+      service_request1 = create(:service_request_without_validations, protocol: @protocol1)
+      create(:sub_service_request, service_request: service_request1, organization: organization1, status: 'draft', protocol_id: @protocol1.id)
+
+      service_request2 = create(:service_request_without_validations, protocol: @protocol2)
+      create(:sub_service_request, service_request: service_request2, organization: organization2, status: 'draft', protocol_id: @protocol2.id)
+
+      service_request3 = create(:service_request_without_validations, protocol: @protocol3)
+      create(:sub_service_request, service_request: service_request3, organization: organization3, status: 'draft', protocol_id: @protocol3.id)
+
+    end
+
+    it 'should save a search and then a user should be able to perform it' do
+      visit_protocols_index_page
+      wait_for_javascript_to_finish
+
+      expect(@page.search_results).to have_protocols(count: 3)
+
+      @page.filter_protocols.search_field.set((@protocol3.principal_investigators.first.last_name).to_s)
+      find('#save_filters_link').click
+      wait_for_javascript_to_finish
+      fill_in 'protocol_filter_search_name', with: 'saved search'
+      click_button 'Save'
+      wait_for_javascript_to_finish
+      find('a.saved_search_link', text: 'saved search').click
+      wait_for_javascript_to_finish
+
+      expect(@page.search_results).to have_no_protocols(text: "Protocol1")
+      expect(@page.search_results).to have_no_protocols(text: "Protocol2")
+      expect(@page.search_results).to have_protocols(text: "Protocol3")
+    end
+  end
+
   # Creates a protocol using FactoryGirl, optionally with a SubServiceRequest
   #
   # @param [Hash] opts Options for creating the Protocol, all but :status and :organization


### PR DESCRIPTION
Since the latest production (v2.0.0), the previous saved filters on
SPARCDashboard are no longer working.

This was caused by an error in the search_query scope. It was expecting
a Hash but was saved as a string. I attempted first to serialize the
attribute as a Hash while converting the data-type to Text, but that was
giving me issues. I ended up just using the #eval method to convert to
hash on ProtocolFilter#href. Also wrote a rake task to fix historical
filters and wrote feature spec where a user interacts with saved
searches. [#142261025]