### PR TITLE
JL separating out site admins and epic queue access groups  

### DIFF
--- a/app/controllers/dashboard/epic_queue_records_controller.rb
+++ b/app/controllers/dashboard/epic_queue_records_controller.rb
@@ -31,7 +31,7 @@ class Dashboard::EpicQueueRecordsController < Dashboard::BaseController
   
   # Check to see if user has rights to view epic queues
   def authorize_overlord
-    unless SITE_ADMINS.include?(@user.ldap_uid)
+    unless EPIC_QUEUE_ACCESS.include?(@user.ldap_uid)
       @epic_queues = nil
       @epic_queue = nil
       render partial: 'service_requests/authorization_error',

--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -50,7 +50,7 @@ class Dashboard::EpicQueuesController < Dashboard::BaseController
 
   # Check to see if user has rights to view epic queues
   def authorize_overlord
-    unless SITE_ADMINS.include?(@user.ldap_uid)
+    unless EPIC_QUEUE_ACCESS.include?(@user.ldap_uid)
       @epic_queues = nil
       @epic_queue = nil
       render partial: 'service_requests/authorization_error', locals: { error: 'You do not have access to view the Epic Queues', in_dashboard: false }

--- a/app/views/dashboard/admin/index.html.haml
+++ b/app/views/dashboard/admin/index.html.haml
@@ -32,7 +32,7 @@
     = link_to "Create A Request", root_path, :class => 'create_new_request header_button btn btn-primary btn-md'
     - if @user.is_super_user?
       = link_to "Reporting", reports_path, :class => 'reporting header_button btn btn-primary btn-md'
-    - if SITE_ADMINS.include?(current_user.ldap_uid)
+    - if EPIC_QUEUE_ACCESS.include?(current_user.ldap_uid)
       = link_to "View Epic Queue", dashboard_epic_queues_path, :class => 'epic_queues header_button btn btn-primary btn-md'
 
 = render :partial => 'ssr_list'

--- a/app/views/layouts/dashboard/_dashboard_header.html.haml
+++ b/app/views/layouts/dashboard/_dashboard_header.html.haml
@@ -35,6 +35,7 @@
           %li
             %button.btn.btn-info.navbar-btn#survey-btn{ type: 'button'}
               = t(:dashboard)[:navbar][:surveys]
+        - if EPIC_QUEUE_ACCESS.include?(user.ldap_uid)
           %li
             %button.btn.btn-info.navbar-btn#epic-queue-btn{ type: 'button'}
               = t(:dashboard)[:navbar][:epic_queue]

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -49,6 +49,7 @@ development:
   queue_epic: true
   queue_epic_load_error_to: 'hutsonk@musc.edu, forney@musc.edu, crossoml@musc.edu, success@musc.edu'
   site_admins: ['jug2@musc.edu']
+  epic_queue_access: ['jug2@musc.edu']
   use_google_calendar: true
   # insert sub-directory path to override the three header images + account sign-in image and override application.css
 #  custom_asset_path: image_override/
@@ -130,6 +131,7 @@ test:
   queue_epic: false
   queue_epic_load_error_to: 'hutsonk@musc.edu, forney@musc.edu, crossoml@musc.edu, success@musc.edu'
   site_admins: ['jug2']
+  epic_queue_access: ['jug2']
   use_google_calendar: true
   # insert sub-directory path to override the three header images + account sign-in image and override application.css
 #  custom_asset_path: image_override/

--- a/config/initializers/01_obis_setup.rb
+++ b/config/initializers/01_obis_setup.rb
@@ -54,6 +54,7 @@ begin
   USE_EPIC                                  = application_config['use_epic']
   QUEUE_EPIC                                = application_config['queue_epic']
   QUEUE_EPIC_LOAD_ERROR_TO                  = application_config['queue_epic_load_error_to']
+  EPIC_QUEUE_ACCESS                         = application_config['epic_queue_access'] || []
   SITE_ADMINS                               = application_config['site_admins'] || []
   EPIC_QUEUE_REPORT_TO                      = application_config['epic_queue_report_to']
   USE_GOOGLE_CALENDAR                       = application_config['use_google_calendar']


### PR DESCRIPTION
Adding back in epic access users who only have rights to see the epic queue button and the functionality within. Site Admins have access to both the epic queue and the survey module.