### PR TITLE
JL Redirect to dashboard after last service deletion

### DIFF
--- a/app/assets/javascripts/cart.js.coffee
+++ b/app/assets/javascripts/cart.js.coffee
@@ -91,7 +91,7 @@ $(document).ready ->
       $('#modal_place .yes-button').on 'click', (e) ->
         button.replaceWith(spinner)
         window.cart.removeService(srid, ssrid, id, false, spinner, editing_ssr)
-    else if (editing_ssr == 1) && (li_count == 1) && (window.location.pathname.indexOf('catalog') != -1) # Redirect to the Dashboard if the user deletes the last Service on an SSR
+    else if (editing_ssr == 1) && (li_count == 1) # Redirect to the Dashboard if the user deletes the last Service on an SSR
       $('#modal_place').html($('#remove-request-modal').html())
       $('#modal_place').modal('show')
 


### PR DESCRIPTION
When you come back into sparc proper from dashboard by editing a single ssr, a user should be redirected back to dashboard after deleting the last service from their cart. This should happen on all steps in proper, not just the catalog page.