### PR TITLE
There are differences between the staging and production api tokens. On

### DIFF
--- a/lib/redcap_survey_emitter.rb
+++ b/lib/redcap_survey_emitter.rb
@@ -7,17 +7,34 @@ class RedcapSurveyEmitter
   end
 
   def send_form
-    record = {
-      :letters => latest_letter_id + 1,
-      :name => @feedback.name,
-      :email => @feedback.email,
-      :date => Date.strptime(@feedback.date[0..9], '%m/%d/%Y').strftime("%Y/%m/%d").gsub('/', '-'),
-      :typeofrequest => @feedback.typeofrequest,
-      :priority => @feedback.priority,
-      :browser => @feedback.browser,
-      :version => @feedback.version,
-      :sparc_request_id => @feedback.sparc_request_id
+    #the RedCap API token has differing fields between staging and production.
+    #Due to potential data loss, we cannot change those fields on RedCap itself,
+    #therefore here we are specifying different params based on Rails.env
+    if Rails.env.production?
+      record = {
+        :letters => latest_letter_id + 1,
+        :name => @feedback.name,
+        :email => @feedback.email,
+        :date => Date.strptime(@feedback.date[0..9], '%m/%d/%Y').strftime("%Y/%m/%d").gsub('/', '-'),
+        :type => @feedback.typeofrequest,
+        :priority => @feedback.priority,
+        :browser => @feedback.browser,
+        :version => @feedback.version,
+        :sparc_request_id => @feedback.sparc_request_id
       }
+    else
+      record = {
+        :letters => latest_letter_id + 1,
+        :name => @feedback.name,
+        :email => @feedback.email,
+        :date => Date.strptime(@feedback.date[0..9], '%m/%d/%Y').strftime("%Y/%m/%d").gsub('/', '-'),
+        :typeofrequest => @feedback.typeofrequest,
+        :priority => @feedback.priority,
+        :browser => @feedback.browser,
+        :version => @feedback.version,
+        :sparc_request_id => @feedback.sparc_request_id
+      }
+    end
 
     data = [record].to_json
 


### PR DESCRIPTION
production there is a field called 'type', while on staging it is called
'typeofrequest'. We can't change this on RedCap because we could
potentially lose data from this attribute. I ended up just setting a
conditional based on our Rails.env. I don't think you can change keys
conditionally, the only things I found were conditionally changing
values in a hash. If anyone has a cleaner solution, feel free to offer
it up. [#142789871]