### PR TITLE
wth - (SPARCReport) Generate Report Button Disabled After Running a

### DIFF
--- a/app/views/reports/_setup.html.haml
+++ b/app/views/reports/_setup.html.haml
@@ -29,7 +29,7 @@
 
         = render "reports/form_partials/#{options[:field_type]}_form_partial", options: options, field_label: field_label, field: field
   .report-actions.text-center
-    = submit_tag t(:reporting)[:actions][:create], class: "btn btn-success"
+    = submit_tag t(:reporting)[:actions][:create], class: "btn btn-success", data: { disable_with: false }
     = button_to t(:reporting)[:actions][:return], reports_path, method: :get, id: "reporting-return-to-list", class: "btn btn-primary"
 %br
 %br


### PR DESCRIPTION
Report

Per docs -
http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag

Set data attribute 'disable_with' to false and it will prevent disabling
button on click. [#144698525]