### PR TITLE
SAW - persistent dashboard filter values

### DIFF
--- a/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
+++ b/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
@@ -39,8 +39,8 @@
               = form.fields_for :search_query do |search|
                 .input-group-btn
                   .dd_select
-                    = search.select :search_drop, t(:dashboard)[:protocol_filters][:search_by_options], { prompt:  t(:dashboard)[:protocol_filters][:search_by] }, class: "form-control selectpicker ", data: { style: 'dropdown_filter' }
-                = search.text_field :search_text, class: 'form-control'
+                    = search.select :search_drop, options_for_select(t(:dashboard)[:protocol_filters][:search_by_options], filterrific.search_query.try(:search_drop)), { prompt:  t(:dashboard)[:protocol_filters][:search_by] }, class: "form-control selectpicker ", data: { style: 'dropdown_filter' }
+                = search.text_field :search_text, value: filterrific.search_query.try(:search_text), class: 'form-control'
 
         .form-group.row
           = form.label :show_archived, t(:dashboard)[:protocol_filters][:archived], class: 'col-lg-10 control-label'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/145701595
The search box in the dashboard protocols filter now holds its text value and dropdown value after applying a filter.