### PR TITLE
wth - (SPARCDashboard) Your Cost bad data

### DIFF
--- a/app/models/concerns/service_utility.rb
+++ b/app/models/concerns/service_utility.rb
@@ -1,0 +1,7 @@
+module ServiceUtility
+
+  def self.valid_float?(str)
+    !!Float(str) rescue false
+  end
+end
+

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,6 +21,7 @@
 class Service < ApplicationRecord
 
   include RemotelyNotifiable
+  include ServiceUtility
 
   audited
   acts_as_taggable
@@ -118,7 +119,13 @@ class Service < ApplicationRecord
   # cents.
   def self.dollars_to_cents dollars
     dollars = dollars.gsub(',','')
-    (BigDecimal(dollars) * 100).to_i
+    #check if dollars arg will be a valid for BigDecimal conversion
+    if ServiceUtility.valid_float?(dollars)
+      #if not we convert dollars to an integer
+      (BigDecimal(dollars) * 100).to_i
+    else
+      (BigDecimal(dollars.to_i) * 100).to_i
+    end
   end
 
   # Given an integer number of cents, return a Float representing the


### PR DESCRIPTION
When a user changes the cost of a line item within admin edit, certain
entered strings are causing the page to error out and production bug
emails to be sent. Random strings are being filtered out ('Random
string' will return an error) but entering a partial decimal ('72.')
will cause it to error out.

I added a method to check if the argument will be a valid float
when running BigDecimal(argument), if it isn't, I convert it to an
integer first. [#145657373]