### PR TITLE
wth - (SPARCDashboard) Your Cost bad data

### DIFF
--- a/app/models/concerns/service_utility.rb
+++ b/app/models/concerns/service_utility.rb
@@ -1,0 +1,26 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module ServiceUtility
+
+  def self.valid_float?(str)
+    !!Float(str) rescue false
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,6 +21,7 @@
 class Service < ApplicationRecord
 
   include RemotelyNotifiable
+  include ServiceUtility
 
   audited
   acts_as_taggable
@@ -118,7 +119,13 @@ class Service < ApplicationRecord
   # cents.
   def self.dollars_to_cents dollars
     dollars = dollars.gsub(',','')
-    (BigDecimal(dollars) * 100).to_i
+    #check if dollars arg will be a valid for BigDecimal conversion
+    if ServiceUtility.valid_float?(dollars)
+      #if not we convert dollars to an integer
+      (BigDecimal(dollars) * 100).to_i
+    else
+      (BigDecimal(dollars.to_i) * 100).to_i
+    end
   end
 
   # Given an integer number of cents, return a Float representing the


### PR DESCRIPTION
When a user changes the cost of a line item within admin edit, certain
entered strings are causing the page to error out and production bug
emails to be sent. Random strings are being filtered out ('Random
string' will return an error) but entering a partial decimal ('72.')
will cause it to error out.

I added a method to check if the argument will be a valid float
when running BigDecimal(argument), if it isn't, I convert it to an
integer first. [#145657373]

Pivotal Tracker link -
(https://www.pivotaltracker.com/story/show/145657373)

References: (https://stackoverflow.com/q/1034418)