### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Switching PI Bug

### DIFF
--- a/lib/associated_user_creator.rb
+++ b/lib/associated_user_creator.rb
@@ -29,7 +29,7 @@ class AssociatedUserCreator
       @successful = true
       if @protocol_role.role == 'primary-pi'
         protocol.project_roles.primary_pis.each do |pr|
-          pr.update_attributes(project_rights: 'request', role: 'general-access-user')
+          pr.update_attributes(project_rights: 'approve', role: 'general-access-user')
         end
       end
       @protocol_role.save

--- a/lib/associated_user_updater.rb
+++ b/lib/associated_user_updater.rb
@@ -34,7 +34,7 @@ class AssociatedUserUpdater
 
       if @protocol_role.role == 'primary-pi'
         protocol.project_roles.where(role: 'primary-pi').where.not(identity_id: @protocol_role.identity_id).each do |pr|
-          pr.update_attributes(project_rights: 'request', role: 'general-access-user')
+          pr.update_attributes(project_rights: 'approve', role: 'general-access-user')
         end
       end
 

--- a/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
+++ b/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
@@ -318,7 +318,7 @@ RSpec.feature 'User wants to add an authorized user', js: true do
 
   def then_i_should_see_the_old_primary_pi_has_request_rights
     wait_for_javascript_to_finish
-    expect(ProjectRole.find_by(identity_id: logged_in_user.id, protocol_id: protocol.id).project_rights).to eq('request')
+    expect(ProjectRole.find_by(identity_id: logged_in_user.id, protocol_id: protocol.id).project_rights).to eq('approve')
   end
 
   def then_i_should_see_an_error_of_type error_type

--- a/spec/features/dashboard/protocols/show/authorized_users/edit_authorized_user_spec.rb
+++ b/spec/features/dashboard/protocols/show/authorized_users/edit_authorized_user_spec.rb
@@ -322,7 +322,7 @@ RSpec.feature 'User wants to edit an authorized user', js: true do
 
   def then_i_should_see_the_old_primary_pi_has_request_rights
     wait_for_javascript_to_finish
-    expect(ProjectRole.find_by(identity_id: logged_in_user.id, protocol_id: protocol.id).project_rights).to eq('request')
+    expect(ProjectRole.find_by(identity_id: logged_in_user.id, protocol_id: protocol.id).project_rights).to eq('approve')
   end
 
   def then_i_should_see_an_error_of_type error_type


### PR DESCRIPTION
On SPARCRequest and SPARCDashboard, when switching PIs by adding a new
primary PI on the protocol, it is defaulting the previous PI to
"Request/Approve Services" right, which doesn't exist any more.

I updated the two classes in /lib that handle this update and set the
project rights to 'approve'. [#145688447]

Pivotal Story - (https://www.pivotaltracker.com/story/show/145688447)

Steps to Test:
1. Find existing Protocol
2. Add a new Primary PI, which will replace the old one.
3. Proxy rights should remain as they were.