### PR TITLE
SAW - No emails if can't connect to Google Calendar

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -432,7 +432,7 @@ class ServiceRequestsController < ApplicationController
 
         cal = cals.first
 
-        events = cal.events.sort { |x, y| y.dtstart <=> x.dtstart }
+        events = cal.try(:events).try(:sort) { |x, y| y.dtstart <=> x.dtstart } || []
 
         events.each do |event|
           next if Time.parse(event.dtstart.to_s) > startMax


### PR DESCRIPTION
[#145605101](https://www.pivotaltracker.com/n/projects/1327474/stories/145605101)
If `cal` is nil (couldn't connect to Google Calendar), then load events calendar without any events and don't send an email out for it.