### PR TITLE
KG - Fix Survey Question Validation When Dependent on Option Selection

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -54,7 +54,10 @@ class Surveyor::ResponsesController < ApplicationController
     @review   = params[:review] == 'true'
 
     if @response.save && @response.question_responses.none? { |qr| qr.errors.any? }
+      # Delete responses to questions that didn't show anyways to avoid confusion in the data
+      @response.question_responses.where(required: true, content: [nil, '']).destroy_all
       SurveyNotification.system_satisfaction_survey(@response) if @response.survey.access_code == 'system-satisfaction-survey'
+      
       flash[:success] = t(:surveyor)[:responses][:create]
     else
       @errors = true

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -60,6 +60,8 @@ class Surveyor::ResponsesController < ApplicationController
       
       flash[:success] = t(:surveyor)[:responses][:create]
     else
+      @response.destroy
+      
       @errors = true
     end
   end

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -53,11 +53,11 @@ class Surveyor::ResponsesController < ApplicationController
     @response = Response.new(response_params)
     @review   = params[:review] == 'true'
 
-    if @response.save
+    if @response.save && @response.question_responses.none? { |qr| qr.errors.any? }
       SurveyNotification.system_satisfaction_survey(@response) if @response.survey.access_code == 'system-satisfaction-survey'
       flash[:success] = t(:surveyor)[:responses][:create]
     else
-      @errors = @response.errors
+      @errors = true
     end
   end
 

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -79,7 +79,7 @@ class QuestionResponse < ActiveRecord::Base
   private
 
   def check_content_requirements
-    if self.required? && self.content.blank? && self.depender.present? && depender_selected?
+    if self.required? && self.content.blank? && (self.depender.nil? || self.depender.present? && depender_selected?)
       errors.add(:content, :blank)
     end
   end

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -22,7 +22,7 @@ class QuestionResponse < ActiveRecord::Base
   belongs_to :question
   belongs_to :response
 
-  validates :content, presence: true, if: :required?
+  delegate :depender, to: :question
 
   validate :phone_number_format, if: Proc.new{ |qr| !qr.content.blank? && qr.question_id && qr.question.question_type == 'phone' }
   validate :email_format, if: Proc.new{ |qr| !qr.content.blank? && qr.question_id && qr.question.question_type == 'email' }
@@ -30,6 +30,7 @@ class QuestionResponse < ActiveRecord::Base
   
   validates_numericality_of :content, only_integer: true, if: Proc.new{ |qr| !qr.content.blank? && qr.question_id && qr.question.question_type == 'number' }
 
+  after_save :check_content_requirements
   def phone_number_format
     if content.match(/\d{10}/).nil?
       errors.add(:base, I18n.t(:errors)[:question_responses][:phone_invalid])
@@ -73,5 +74,17 @@ class QuestionResponse < ActiveRecord::Base
     else
       ""
     end
+  end
+
+  private
+
+  def check_content_requirements
+    if self.required? && self.content.blank? && self.depender.present? && depender_selected?
+      errors.add(:content, :blank)
+    end
+  end
+
+  def depender_selected?
+    self.depender && self.response.question_responses.where(question_id: self.depender.question_id).first.content == self.depender.content
   end
 end

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -31,6 +31,7 @@ class QuestionResponse < ActiveRecord::Base
   validates_numericality_of :content, only_integer: true, if: Proc.new{ |qr| !qr.content.blank? && qr.question_id && qr.question.question_type == 'number' }
 
   after_save :check_content_requirements
+  
   def phone_number_format
     if content.match(/\d{10}/).nil?
       errors.add(:base, I18n.t(:errors)[:question_responses][:phone_invalid])

--- a/app/views/surveyor/responses/create.js.coffee
+++ b/app/views/surveyor/responses/create.js.coffee
@@ -30,6 +30,7 @@ $(".question-<%=qr.question_id%>").removeClass('has-error')
 $(".question-<%=qr.question_id%> .help-block").remove()
 <% end %>
 <% end %>
+<% @response.question_responses.destroy_all %>
 <% else %>
 <% if @review %>
 $('#modal_place').modal('hide')

--- a/spec/controllers/surveyor/responses/post_create_spec.rb
+++ b/spec/controllers/surveyor/responses/post_create_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Surveyor::ResponsesController, type: :controller do
           }
         }
 
-        expect(assigns(:errors).count).to eq(true)
+        expect(assigns(:errors)).to eq(true)
       end
     end
 

--- a/spec/controllers/surveyor/responses/post_create_spec.rb
+++ b/spec/controllers/surveyor/responses/post_create_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Surveyor::ResponsesController, type: :controller do
           }
         }
 
-        expect(assigns(:errors).count).to eq(1)
+        expect(assigns(:errors).count).to eq(true)
       end
     end
 

--- a/spec/models/question_response/question_response_spec.rb
+++ b/spec/models/question_response/question_response_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe QuestionResponse, type: :model do
   it { is_expected.to belong_to(:response) }
 
   # Validations
-  it 'should validate presence of content if required' do
-    qr = build(:question_response, required: true, content: nil)
-
-    expect(qr).to_not be_valid
-  end
-
   context 'question_type == phone' do
     it 'should return true if blank' do
       q   = create(:question, question_type: 'phone')

--- a/spec/models/question_response/question_response_spec.rb
+++ b/spec/models/question_response/question_response_spec.rb
@@ -122,4 +122,7 @@ RSpec.describe QuestionResponse, type: :model do
       expect(qr2).to be_valid
     end
   end
+
+  # Callbacks
+  it { is_expected.to callback(:check_content_requirements).after(:save) }
 end


### PR DESCRIPTION
Pivotal Story:
https://www.pivotaltracker.com/story/show/146091507

Feature:
When surveys had questions which were both required and dependent on another option, if that question wasn't filled out, despite the depender option not being selected, it would fail validations. Instead, if the depender option isn't selected, it should ignore validations on the question.

Fix:
Because the presence validation is run pre-save, I didn't have access to the other question responses that I needed to check whether the option was selected. Instead, I had to use an after_save callback to apply errors if the use-case was met, then check for those errors in the controller.