### PR TITLE
SAW - validations on Visits and Visit Groups

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -28,9 +28,9 @@ class Visit < ApplicationRecord
   belongs_to :visit_group
   belongs_to :line_items_visit
   
-  validates :research_billing_qty, numericality: { only_integer: true }
-  validates :insurance_billing_qty, numericality: { only_integer: true }
-  validates :effort_billing_qty, numericality: { only_integer: true }
+  validates :research_billing_qty, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :insurance_billing_qty, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :effort_billing_qty, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   # Find a Visit for the given "line items visit" and visit group.  This
   # creates the visit if it does not exist.

--- a/app/models/visit_group.rb
+++ b/app/models/visit_group.rb
@@ -35,7 +35,7 @@ class VisitGroup < ApplicationRecord
   validates :position, presence: true
   validates :window_before,
             :window_after,
-            presence: true, numericality: { only_integer: true }
+            presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :day, presence: true, numericality: { only_integer: true }
 
   validate :day_must_be_in_order

--- a/spec/models/visit_group_spec.rb
+++ b/spec/models/visit_group_spec.rb
@@ -29,6 +29,88 @@ RSpec.describe "VisitGroup" do
   let!(:visit1)      { create(:visit, visit_group_id: visit_group.id)}         
   let!(:visit2)      { create(:visit, visit_group_id: visit_group.id)}         
 
+  describe 'valid visit' do
+    context 'name' do
+      it 'should not be nil' do
+        visit_group = build(:visit_group, arm_id: arm1.id, name: nil)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:name].blank?).to eq(false)
+      end
+    end
+
+    context 'position' do
+      it 'should not be nil' do
+        visit_group = build(:visit_group, arm_id: arm1.id, position: nil)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:position].blank?).to eq(false)
+      end
+    end
+
+    context 'window_before' do
+      it 'should be a number' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_before: 'string')
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_before].blank?).to eq(false)
+      end
+
+      it 'should not allow negative numbers' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_before: -1)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_before].blank?).to eq(false)
+      end
+
+      it 'should not allow fractions' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_before: 2.7)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_before].blank?).to eq(false)
+      end
+    end
+
+    context 'window_after' do
+      it 'should be a number' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_after: 'string')
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_after].blank?).to eq(false)
+      end
+
+      it 'should not allow negative numbers' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_after: -1)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_after].blank?).to eq(false)
+      end
+
+      it 'should not allow fractions' do
+        visit_group = build(:visit_group, arm_id: arm1.id, window_after: 2.7)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:window_after].blank?).to eq(false)
+      end
+    end
+
+    context 'day' do
+      it 'should not be nil' do
+        visit_group = build(:visit_group, arm_id: arm1.id, day: nil)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:day]).to be
+      end
+
+      it 'should not allow fractions' do
+        visit_group = build(:visit_group, arm_id: arm1.id, day: 2.7)
+        visit_group.save
+
+        expect(visit_group.errors.messages[:day]).to be
+      end
+    end
+  end
+
   describe 'any visit quantities customized' do
     let!(:protocol)          { create(:protocol_without_validations) }
     let!(:arm)               { create(:arm, protocol: protocol) }

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -31,6 +31,77 @@ RSpec.describe 'Visit' do
   let!(:visit_group)       { create(:visit_group, arm_id: arm.id)}
   let!(:visit1)            { create(:visit, line_items_visit_id: line_items_visit1.id, visit_group_id: visit_group.id) }
 
+  describe 'valid visit' do
+    context 'research_billing_qty' do
+      it 'should be a number' do
+        visit = build(:visit, research_billing_qty: 'string')
+        visit.save
+
+        expect(visit.errors.messages[:research_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow negative numbers' do
+        visit = build(:visit, research_billing_qty: -1)
+        visit.save
+
+        expect(visit.errors.messages[:research_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow fractions' do
+        visit = build(:visit, research_billing_qty: 2.7)
+        visit.save
+
+        expect(visit.errors.messages[:research_billing_qty].blank?).to eq(false)
+      end
+    end
+
+    context 'insurance_billing_qty' do
+      it 'should be a number' do
+        visit = build(:visit, insurance_billing_qty: 'string')
+        visit.save
+
+        expect(visit.errors.messages[:insurance_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow negative numbers' do
+        visit = build(:visit, insurance_billing_qty: -1)
+        visit.save
+
+        expect(visit.errors.messages[:insurance_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow fractions' do
+        visit = build(:visit, insurance_billing_qty: 2.7)
+        visit.save
+
+        expect(visit.errors.messages[:insurance_billing_qty].blank?).to eq(false)
+      end
+    end
+
+    context 'effort_billing_qty' do
+      it 'should be a number' do
+        visit = build(:visit, effort_billing_qty: 'string')
+        visit.save
+
+        expect(visit.errors.messages[:effort_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow negative numbers' do
+        visit = build(:visit, effort_billing_qty: -1)
+        visit.save
+
+        expect(visit.errors.messages[:effort_billing_qty].blank?).to eq(false)
+      end
+
+      it 'should not allow fractions' do
+        visit = build(:visit, effort_billing_qty: 2.7)
+        visit.save
+
+        expect(visit.errors.messages[:effort_billing_qty].blank?).to eq(false)
+      end
+    end
+  end
+
   describe 'quantities customized' do
 
     it 'should return false if the quantities are untouched, or set to the default checked state' do


### PR DESCRIPTION
[#146158043](https://www.pivotaltracker.com/story/show/146158043)
Visits validate that the R, T and % billing quantities are nonnegative, same with Visit Group `window_before` and `window_after`