### PR TITLE
KG - Protocol Filter Randomly Failing Specs

### DIFF
--- a/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_admin_protocols_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_admin_protocols_with_search_spec.rb
@@ -299,9 +299,13 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
 
   context "HR# search" do
     before :each do
-      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3")
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", human_subjects_info: hsi3)
 
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)
       service_request2 = create(:service_request_without_validations, protocol: @protocol2)
@@ -405,9 +409,13 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
 
   context "All search" do
     before :each do
-      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234)
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234, human_subjects_info: hsi3)
       @protocol4 = create(:project_without_validations, id: 888888, primary_pi: jug2, title: "101010101", short_title: "Protocol4")
       
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)

--- a/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_protocols_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_protocols_with_search_spec.rb
@@ -299,9 +299,13 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
 
   context "HR# search" do
     before :each do
-      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3")
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", human_subjects_info: hsi3)
 
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)
       service_request2 = create(:service_request_without_validations, protocol: @protocol2)
@@ -405,10 +409,14 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
 
   context "All search" do
     before :each do
-      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234)
-      @protocol4 = create(:project_without_validations, id: 888888, primary_pi: jug2, title: "101010101", short_title: "Protocol4")
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234, human_subjects_info: hsi3)
+      @protocol4 = create(:project_without_validations, id: 888888, primary_pi: jug2, title: "TheRubyRacer", short_title: "Protocol4")
       
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)
       service_request2 = create(:service_request_without_validations, protocol: @protocol2)
@@ -646,7 +654,7 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
     end
 
     it 'should return projects and not just studies' do
-      fill_in 'filterrific_search_query_search_text', with: '101'
+      fill_in 'filterrific_search_query_search_text', with: 'Ruby'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
       

--- a/spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb
@@ -272,9 +272,13 @@ RSpec.describe "General User filters using Search functionality", js: :true do
 
   context "HR# search" do
     before :each do
-      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3")
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", human_subjects_info: hsi3)
 
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)
       service_request2 = create(:service_request_without_validations, protocol: @protocol2)
@@ -370,10 +374,14 @@ RSpec.describe "General User filters using Search functionality", js: :true do
 
   context "All search" do
     before :each do
-      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1")
-      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
-      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234)
-      @protocol4 = create(:project_without_validations, id: 888888, primary_pi: jug2, title: "101010101", short_title: "Protocol4")
+      hsi1       = create(:human_subjects_info, hr_number: 111111)
+      hsi2       = create(:human_subjects_info, hr_number: 222222)
+      hsi3       = create(:human_subjects_info, hr_number: 333333)
+
+      @protocol1 = create(:study_without_validations, id: 555555, primary_pi: jug2, title: "title%", short_title: "Protocol1", human_subjects_info: hsi1)
+      @protocol2 = create(:study_without_validations, id: 666666, primary_pi: jug2, title: "xTitle", short_title: "Protocol2", human_subjects_info: hsi2)
+      @protocol3 = create(:study_without_validations, id: 777777, primary_pi: other_user, title: @protocol1.id.to_s, short_title: "Protocol3", research_master_id: 1234, human_subjects_info: hsi3)
+      @protocol4 = create(:project_without_validations, id: 888888, primary_pi: jug2, title: "TheRubyRacer", short_title: "Protocol4")
       
       service_request1 = create(:service_request_without_validations, protocol: @protocol1)
       service_request2 = create(:service_request_without_validations, protocol: @protocol2)
@@ -607,7 +615,7 @@ RSpec.describe "General User filters using Search functionality", js: :true do
     end
 
     it 'should return projects and not just studies' do
-      fill_in 'filterrific_search_query_search_text', with: '101'
+      fill_in 'filterrific_search_query_search_text', with: 'Ruby'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
       


### PR DESCRIPTION
Most of the failures seem to revolve around randomly generated values in factories which are causing unexpected protocols to be displayed by the filter. I assigned HR#s to the specs that use it as a filter to hopefully avoid that issue, and changed the title of the Projects to hopefully avoid conflicting with titles or other values.

Spec Failures:
```
1) General User filters using Search functionality HR# search should match against partial HR#
     Failure/Error: expect(page).to have_selector(".protocols_index_row", count: 1)
       expected to find css ".protocols_index_row" 1 time, found 2 matches: "3 Protocol3 Julia Glenn", "2 Protocol2 Julia Glenn"
     # ./spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb:307:in `block (3 levels) in <top (required)>'
```
```
1) Admin User filters My Protocols using Search functionality All search should return projects and not just studies
     Failure/Error: expect(page).to have_selector(".protocols_index_row", count: 1)
       expected to find css ".protocols_index_row" 1 time, found 2 matches: "888888 Protocol4 Julia Glenn", "666666 Protocol2 Julia Glenn"
     # ./spec/features/dashboard/protocols/index/filters/admin_user_filters_my_protocols_with_search_spec.rb:653:in `block (3 levels) in <top (required)>'
```

```
1) General User filters using Search functionality All search should return projects and not just studies
     Failure/Error: expect(page).to have_selector(".protocols_index_row", count: 1)
       expected to find css ".protocols_index_row" 1 time, found 2 matches: "888888 Protocol4 Julia Glenn", "555555 Protocol1 Julia Glenn"
     # ./spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb:618:in `block (3 levels) in <top (required)>'
```