### PR TITLE
SAW - update header logos adjustments

### DIFF
--- a/app/assets/stylesheets/dashboard/layout.sass
+++ b/app/assets/stylesheets/dashboard/layout.sass
@@ -27,15 +27,17 @@
     text-align: center
 
   .org-logo
-    margin-left: 50px
     margin-top: 15px
+    margin-right: 50px
+    float: right
 
   .sparc-request-header
-    margin-top: 15px
+    margin-top: 35px
 
   .institution-logo
     margin-top: 15px
-    margin-left: 25px
+    margin-left: 50px
+    float: left
 
 .footer
   margin-left: auto

--- a/app/assets/stylesheets/proper/layout.sass
+++ b/app/assets/stylesheets/proper/layout.sass
@@ -30,15 +30,17 @@
       text-align: center
 
     .org-logo
-      margin-left: 50px
       margin-top: 15px
+      margin-right: 50px
+      float: right
 
     .sparc-request-header
-      margin-top: 15px
+      margin-top: 35px
 
     .institution-logo
       margin-top: 15px
-      margin-left: 25px
+      margin-left: 50px
+      float: left
 
   .navbar
     @media(max-width: 768px)

--- a/app/views/layouts/_header_logos.html.haml
+++ b/app/views/layouts/_header_logos.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .col-md-3
   %a{ href: HEADER_LINK_1 }
-    = image_tag 'sctr_header.jpg', alt: 'org_logo', class: 'org-logo', height: 110
+    = image_tag 'sctr_header.jpg', alt: 'org_logo', class: 'org-logo', height: 140
 .col-md-6
   - if location == "proper"
     %a{ href: HEADER_LINK_2_PROPER }
@@ -29,4 +29,4 @@
       = image_tag 'dashboard/logos/dashboard_logo.jpg', alt: 'dashboard_logo', class: 'sparc-request-header', height: 110
 .col-md-3
   %a{ href: HEADER_LINK_3, target: '_blank' }
-    = image_tag 'musc_header.jpg', alt: 'institution_logo', class: 'institution-logo', height: 110
+    = image_tag 'musc_header.jpg', alt: 'institution_logo', class: 'institution-logo', height: 140


### PR DESCRIPTION
[#146109987](https://www.pivotaltracker.com/story/show/146109987)
I made the SCTR and MUSC logos a little larger so that the SCTR logo is readable, the MUSC logo is larger so it's not lopsided, and made the spacing between the MUSC/SCTR logo and the SPARC logo even.