### PR TITLE
JM - Perfect Storm Spec Failure

### DIFF
--- a/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
+++ b/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'User sets each Service Calendar field', js: true do
     visit dashboard_sub_service_request_path(ssr)
     wait_for_javascript_to_finish
 
-    click_link 'Study Schedule'
+    click_link 'Clinical Services'
     
     wait_for_javascript_to_finish
   end

--- a/spec/features/dashboard/admin_edit/admin_interacts_with_template_tab_spec.rb
+++ b/spec/features/dashboard/admin_edit/admin_interacts_with_template_tab_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'User interacts with Template tab', js: true do
     visit dashboard_sub_service_request_path(ssr)
     wait_for_javascript_to_finish
 
-    click_link 'Study Schedule'
+    click_link 'Clinical Services'
     click_link 'Template Tab'
     wait_for_javascript_to_finish
 
@@ -64,7 +64,7 @@ RSpec.describe 'User interacts with Template tab', js: true do
       visit dashboard_sub_service_request_path(ssr)
       wait_for_javascript_to_finish
 
-      click_link 'Study Schedule'
+      click_link 'Clinical Services'
       click_link 'Template Tab'
       wait_for_javascript_to_finish
 
@@ -88,7 +88,7 @@ RSpec.describe 'User interacts with Template tab', js: true do
 
       visit dashboard_sub_service_request_path(ssr)
       wait_for_javascript_to_finish
-      click_link 'Study Schedule'
+      click_link 'Clinical Services'
       wait_for_javascript_to_finish
 
       expect(page).to have_selector('.alert-danger', text: "There are no clinical services requested.")
@@ -112,7 +112,7 @@ RSpec.describe 'User interacts with Template tab', js: true do
       visit dashboard_sub_service_request_path(ssr)
       wait_for_javascript_to_finish
 
-      click_link 'Study Schedule'
+      click_link 'Clinical Services'
       click_link 'Template Tab'
       wait_for_javascript_to_finish
 


### PR DESCRIPTION
In the last push to master, on one of my branches I wrote specs that relied on old syntax.  In another branch I changed the old syntax to the new syntax.  This perfect storm of PR's caused a Master Spec Failure.  