### PR TITLE
KG - Survey Dependents Bugs

### DIFF
--- a/app/assets/javascripts/surveyor/surveys.js.coffee
+++ b/app/assets/javascripts/surveyor/surveys.js.coffee
@@ -49,6 +49,54 @@ $(document).ready ->
       type: 'get'
       url: "/surveyor/surveys/#{survey_id}/preview.js"
 
+  $(document).on 'click', '.add-section', ->
+    $.ajax
+      type: 'post'
+      url: '/surveyor/sections'
+      data:
+        survey_id: $('.survey').data('survey-id')
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
+  $(document).on 'click', '.delete-section', ->
+    $.ajax
+      type: 'delete'
+      url: "/surveyor/sections/#{$(this).parents('.section').data('section-id')}"
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
+  $(document).on 'click', '.add-question', ->
+    $.ajax
+      type: 'post'
+      url: '/surveyor/questions'
+      data:
+        section_id: $(this).parents('.section').data('section-id')
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
+  $(document).on 'click', '.delete-question', ->
+    $.ajax
+      type: 'delete'
+      url: "/surveyor/questions/#{$(this).parents('.question').data('question-id')}"
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
+  $(document).on 'click', '.add-option', ->
+    $.ajax
+      type: 'post'
+      url: '/surveyor/options'
+      data:
+        question_id: $(this).parents('.question').data('question-id')
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
+  $(document).on 'click', '.delete-option', ->
+    $.ajax
+      type: 'delete'
+      url: "/surveyor/options/#{$(this).parents('.option').data('option-id')}"
+      success: ->
+        build_dependents_selectpicker($('.survey').data('survey-id'))
+
   $(document).on 'change', '.select-depender, .select-question-type', ->
     send_update_request($(this), $(this).val())
 
@@ -80,6 +128,9 @@ send_update_request = (obj, val) ->
       klass: klass
       "#{klass}":
         "#{attribute}": val
+    success: ->
+      if attribute == 'question_type'
+        build_dependents_selectpicker($('.survey').data('survey-id'))
 
 (exports ? this).build_dependents_selectpicker = (survey_id) ->
   $.ajax

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -23,8 +23,16 @@ class Option < ActiveRecord::Base
 
   delegate :survey, to: :question
 
-  has_many :dependents, class_name: 'Question', foreign_key: :depender_id, dependent: :destroy
+  has_many :dependents, class_name: 'Question', foreign_key: :depender_id
 
   validates :content,
             presence: true
+
+  before_destroy :update_dependents
+
+  private
+
+  def update_dependents
+    self.dependents.update_all(depender_id: nil)
+  end
 end

--- a/app/views/surveyor/options/create.js.coffee
+++ b/app/views/surveyor/options/create.js.coffee
@@ -18,4 +18,3 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 $(".question-options[data-question-id='<%=@question.id%>']").html('<%= j render "surveyor/surveys/form/form_partials/#{@question.question_type}_example", question: @question %>')
-build_dependents_selectpicker("<%=@option.survey.id%>")

--- a/app/views/surveyor/options/destroy.js.coffee
+++ b/app/views/surveyor/options/destroy.js.coffee
@@ -18,4 +18,3 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 $(".question-options[data-question-id='<%=@option.question.id%>']").html('<%= j render "surveyor/surveys/form/form_partials/#{@option.question.question_type}_example", question: @option.question %>')
-build_dependents_selectpicker("<%=@option.survey.id%>")

--- a/app/views/surveyor/questions/destroy.js.coffee
+++ b/app/views/surveyor/questions/destroy.js.coffee
@@ -20,4 +20,3 @@
 if $(".question-<%=@question.id%>").is(':first-child')
   $(".question-<%=@question.id%>").next().find('#question-is_dependent').prop('disabled', 'disabled')
 $(".question-<%=@question.id%>").remove()
-build_dependents_selectpicker("<%=@question.survey.id%>")

--- a/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
@@ -19,12 +19,12 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .form-group
   - question.options.each do |option|
-    .col-lg-2.no-padding{ data: { question_id: question.id, option_id: option.id } }
+    .col-lg-2.no-padding
       - if ['new', 'preview'].include?(action_name)
-        .col-lg-6.no-padding.text-center.option
+        .col-lg-6.no-padding.text-center.option{ data: { question_id: question.id, option_id: option.id } }
           = qr.radio_button :content, option.content.downcase
         = option.content
       - else
-        .col-lg-6.no-padding.text-center.option
+        .col-lg-6.no-padding.text-center.option{ data: { question_id: question.id, option_id: option.id } }
           = radio_button_tag :content_yes_no, option.content.downcase, qr.content == option.content.downcase, disabled: true
         = option.content

--- a/app/views/surveyor/surveys/form/_survey_content.html.haml
+++ b/app/views/surveyor/surveys/form/_survey_content.html.haml
@@ -32,4 +32,5 @@
         = render 'surveyor/surveys/form/survey_section', survey: survey, section: section
 
     .form-group
-      = link_to add_section_content, surveyor_sections_path(survey_id: survey.id), method: :post, remote: true, class: 'btn btn-sm btn-primary add-section'
+      %button.btn.btn-sm.btn-primary.add-section
+        = add_section_content

--- a/app/views/surveyor/surveys/form/_survey_question.html.haml
+++ b/app/views/surveyor/surveys/form/_survey_question.html.haml
@@ -44,7 +44,7 @@
         .col-sm-4
           = render 'surveyor/surveys/form/dependent_dropdown', survey: survey, question: question
     .col-sm-1.no-padding.pull-right
-      = link_to surveyor_question_path(question), method: :delete, remote: true, class: 'btn btn-danger pull-right delete-question', title: t(:surveyor)[:surveys][:form][:content][:question][:delete], data: { toggle: 'tooltip', animation: 'false' } do 
+      %button.btn.btn-sm.btn-danger.pull-right.delete-question{ title: t(:surveyor)[:surveys][:form][:content][:question][:delete], data: { toggle: 'tooltip', animation: 'false' } }
         %span.glyphicon.glyphicon-trash
 
   .question-options{ data: { question_id: question.id } }

--- a/app/views/surveyor/surveys/form/_survey_section.html.haml
+++ b/app/views/surveyor/surveys/form/_survey_section.html.haml
@@ -28,7 +28,7 @@
             .col-sm-11.no-padding
               = text_field_tag "section-title", section.title, class: 'form-control', placeholder: t(:surveyor)[:surveys][:form][:content][:section][:title][:placeholder], maxlength: 255
             .col-sm-1.no-padding
-              = link_to surveyor_section_path(section), method: :delete, remote: true, class: 'btn btn-danger pull-right delete-section', title: t(:surveyor)[:surveys][:form][:content][:section][:delete], data: { toggle: 'tooltip', animation: 'false' } do
+              %button.btn.btn-sm.btn-danger.pull-right.delete-section{ title: t(:surveyor)[:surveys][:form][:content][:section][:delete], data: { toggle: 'tooltip', animation: 'false' } }
                 %span.glyphicon.glyphicon-trash
     .panel-body
       .form-group
@@ -40,4 +40,5 @@
           = render 'surveyor/surveys/form/survey_question', survey: survey, section: section, question: question
 
       .form-group
-        = link_to add_question_content, surveyor_questions_path(section_id: section.id), method: :post, remote: true, class: 'btn btn-sm btn-primary add-question'
+        %button.btn.btn-sm.btn-primary.add-question
+          = add_question_content

--- a/app/views/surveyor/surveys/form/form_partials/_add_option_button.html.haml
+++ b/app/views/surveyor/surveys/form/form_partials/_add_option_button.html.haml
@@ -17,6 +17,6 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 .form-group
-  = link_to t(:surveyor)[:surveys][:form][:content][:option][:add], surveyor_options_path(question_id: question.id), method: :post, remote: true, class: 'btn btn-sm btn-primary add-option'
+  %button.btn.btn-sm.btn-primary.add-option
+    = t(:surveyor)[:surveys][:form][:content][:option][:add]

--- a/app/views/surveyor/surveys/form/form_partials/_delete_option_button.html.haml
+++ b/app/views/surveyor/surveys/form/form_partials/_delete_option_button.html.haml
@@ -17,15 +17,5 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-%hr
-.col-sm-12
-  - question.options.each do |option|
-    .form-group.option{ data: { option_id: option.id } }
-      .col-lg-1.text-center
-        = check_box_tag :response_example, '', false, class: 'checkbox-example', disabled: true
-      .col-lg-10.no-padding
-        = text_field_tag "option-content", option.content, class: 'form-control option-content', placeholder: t(:surveyor)[:surveys][:form][:content][:option][:content][:placeholder], maxlength: 255
-      .col-lg-1.no-padding
-        = render 'surveyor/surveys/form/form_partials/delete_option_button'
-  = render 'surveyor/surveys/form/form_partials/add_option_button', question: question
+%button.btn.btn-sm.btn-danger.pull-right.delete-option{ title: t(:surveyor)[:surveys][:form][:content][:option][:delete], data: { toggle: 'tooltip', animation: 'false' } }
+  %span.glyphicon.glyphicon-trash

--- a/app/views/surveyor/surveys/form/form_partials/_dropdown_example.html.haml
+++ b/app/views/surveyor/surveys/form/form_partials/_dropdown_example.html.haml
@@ -24,6 +24,5 @@
       .col-lg-11.no-padding
         = text_field_tag "option-content", option.content, class: 'form-control option-content', placeholder: t(:surveyor)[:surveys][:form][:content][:option][:content][:placeholder], maxlength: 255
       .col-lg-1.no-padding
-        = link_to surveyor_option_path(option), method: :delete, remote: true, class: 'btn btn-danger pull-right delete-option', title: t(:surveyor)[:surveys][:form][:content][:option][:delete], data: { toggle: 'tooltip', animation: 'false' } do
-          %span.glyphicon.glyphicon-trash
+        = render 'surveyor/surveys/form/form_partials/delete_option_button'
   = render 'surveyor/surveys/form/form_partials/add_option_button', question: question

--- a/app/views/surveyor/surveys/form/form_partials/_radio_button_example.html.haml
+++ b/app/views/surveyor/surveys/form/form_partials/_radio_button_example.html.haml
@@ -17,7 +17,6 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 %hr
 .col-sm-12
   - question.options.each do |option|
@@ -27,6 +26,5 @@
       .col-lg-10.no-padding
         = text_field_tag "option-content", option.content, class: 'form-control option-content', placeholder: t(:surveyor)[:surveys][:form][:content][:option][:content][:placeholder], maxlength: 255
       .col-lg-1.no-padding
-        = link_to surveyor_option_path(option), method: :delete, remote: true, class: 'btn btn-danger pull-right delete-option', title: t(:surveyor)[:surveys][:form][:content][:option][:delete], data: { toggle: 'tooltip', animation: 'false' } do
-          %span.glyphicon.glyphicon-trash
-  = render 'surveyor/surveys/form/form_partials/add_option_button', question: question
+        = render 'surveyor/surveys/form/form_partials/delete_option_button'
+  = render 'surveyor/surveys/form/form_partials/add_option_button'


### PR DESCRIPTION
Pivotal:
https://www.pivotaltracker.com/story/show/145965119
https://www.pivotaltracker.com/story/show/145875313

1. When changing a question's type that has options and question dependent on its options, do not delete the dependent questions. Instead, remove their dependency.
2. When doing 1, refresh all of the dependents dropdowns to show the changes
3. When adding/removing sections, questions, and options, refresh dependents selectpickers (most of these were already happening, but moved to AJAX Success to improve user experience, and added functionality to sections because I realized they might have dependency issues)