### PR TITLE
KG - Remove Editable Statuses Initializer (After #352 Ran on Production)

### DIFF
--- a/config/initializers/01_obis_setup.rb
+++ b/config/initializers/01_obis_setup.rb
@@ -71,7 +71,6 @@ begin
   CONSTANTS_YML_OVERRIDE                    = application_config['constants_yml_override'] || ''
   SYSTEM_SATISFACTION_SURVEY                = application_config['system_satisfaction_survey'] || false
   NO_REPLY_FROM                             = application_config['no_reply_from']
-  EDITABLE_STATUSES                         = application_config['editable_statuses'] || {}
   UPDATABLE_STATUSES                        = application_config['updatable_statuses'] || []
   FINISHED_STATUSES                         = application_config['finished_statuses'] || []
   REMOTE_SERVICE_NOTIFIER_PROTOCOL          = application_config['remote_service_notifier_protocol']


### PR DESCRIPTION
To preserve existing EDITABLE_STATUSES, this should not be merged until the migration from #352  is ran on Production to add them to the database.